### PR TITLE
Allow posting and getting different types

### DIFF
--- a/RESTFulSense/Clients/IRESTFulApiClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiClient.cs
@@ -13,6 +13,7 @@ namespace RESTFulSense.Clients
         ValueTask<T> GetContentAsync<T>(string relativeUrl);
         ValueTask<string> GetContentStringAsync(string relativeUrl);
         ValueTask<T> PostContentAsync<T>(string relativeUrl, T content);
+        ValueTask<TResult> PostContentAsync<TContent, TResult>(string relativeUrl, TContent content);
         ValueTask<T> PutContentAsync<T>(string relativeUrl, T content);
         ValueTask<T> PutContentAsync<T>(string relativeUrl);
         ValueTask DeleteContentAsync(string relativeUrl);

--- a/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
@@ -13,6 +13,7 @@ namespace RESTFulSense.Clients
         ValueTask<T> GetContentAsync<T>(string relativeUrl);
         ValueTask<string> GetContentStringAsync(string relativeUrl);
         ValueTask<T> PostContentAsync<T>(string relativeUrl, T content);
+        ValueTask<TResult> PostContentAsync<TContent, TResult>(string relativeUrl, TContent content);
         ValueTask<T> PutContentAsync<T>(string relativeUrl, T content);
         ValueTask<T> PutContentAsync<T>(string relativeUrl);
         ValueTask DeleteContentAsync(string relativeUrl);

--- a/RESTFulSense/Clients/RESTFulApiClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiClient.cs
@@ -25,7 +25,10 @@ namespace RESTFulSense.Clients
         public async ValueTask<string> GetContentStringAsync(string relativeUrl) =>
             await GetStringAsync(relativeUrl);
 
-        public async ValueTask<T> PostContentAsync<T>(string relativeUrl, T content)
+        public ValueTask<T> PostContentAsync<T>(string relativeUrl, T content) =>
+            PostContentAsync<T, T>(relativeUrl, content);
+
+        public async ValueTask<TResult> PostContentAsync<TContent, TResult>(string relativeUrl, TContent content)
         {
             StringContent contentString = StringifyJsonifyContent(content);
 
@@ -34,7 +37,7 @@ namespace RESTFulSense.Clients
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
-            return await DeserializeResponseContent<T>(responseMessage);
+            return await DeserializeResponseContent<TResult>(responseMessage);
         }
 
         public async ValueTask<T> PutContentAsync<T>(string relativeUrl, T content)

--- a/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
@@ -32,7 +32,10 @@ namespace RESTFulSense.Clients
         public async ValueTask<string> GetContentStringAsync(string relativeUrl) =>
             await this.httpClient.GetStringAsync(relativeUrl);
 
-        public async ValueTask<T> PostContentAsync<T>(string relativeUrl, T content)
+        public ValueTask<T> PostContentAsync<T>(string relativeUrl, T content) =>
+            PostContentAsync<T, T>(relativeUrl, content);
+
+        public async ValueTask<TResult> PostContentAsync<TContent, TResult>(string relativeUrl, TContent content)
         {
             StringContent contentString = StringifyJsonifyContent(content);
 
@@ -41,7 +44,7 @@ namespace RESTFulSense.Clients
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
-            return await DeserializeResponseContent<T>(responseMessage);
+            return await DeserializeResponseContent<TResult>(responseMessage);
         }
 
         public async ValueTask<T> PutContentAsync<T>(string relativeUrl, T content)


### PR DESCRIPTION
This PR enables getting and posting different types.
This is important if we post to the server an entity and we expected an entity of a different structure back from server.