### PR TITLE
Added timeout functionality to GetContentAsync method.

### DIFF
--- a/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
@@ -4,8 +4,10 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RESTFulSense.Services;
@@ -23,6 +25,19 @@ namespace RESTFulSense.Clients
         {
             HttpResponseMessage responseMessage =
                 await this.httpClient.GetAsync(relativeUrl);
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent<T>(responseMessage);
+        }
+
+        public async ValueTask<T> GetContentAsync<T>(string relativeUrl, TimeSpan timeout)
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(timeout);
+
+            HttpResponseMessage responseMessage =
+                await this.httpClient.GetAsync(relativeUrl, cancellationTokenSource.Token);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 


### PR DESCRIPTION
This adds a possibility to set custom timeout for each request instead of setting HttpClient.Timeout which is used for all requests.
It's just a proposition. I needed this in my application. Would be grateful for your opinion (no matter positive or negative) and suggestions. If you agree that this should be added then I'll write all required methods.