### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/RESTFulSense.Tests/RESTFulSense.Tests.csproj
+++ b/RESTFulSense.Tests/RESTFulSense.Tests.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.6" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@hassanhabib, I found an issue in the RESTFulSense.Tests.csproj:

Packages Microsoft.NET.Test.Sdk v16.6.1, Tynamix.ObjectFiller v1.5.5 and xunit.runner.visualstudio v2.4.2 transitively introduce 78 dependencies into RESTFulSense’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/RESTFulSense.html)), while Microsoft.NET.Test.Sdk v16.9.1, Tynamix.ObjectFiller v1.5.6 and xunit.runner.visualstudio v2.4.3 can only introduce 49 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/RESTFulSense_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose