### PR TITLE
CODE RUB: Support Any Media Type for PUT & POST

### DIFF
--- a/RESTFulSense/Clients/IRESTFulApiClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiClient.cs
@@ -12,10 +12,20 @@ namespace RESTFulSense.Clients
     {
         ValueTask<T> GetContentAsync<T>(string relativeUrl);
         ValueTask<string> GetContentStringAsync(string relativeUrl);
-        ValueTask<T> PostContentAsync<T>(string relativeUrl, T content);
-        ValueTask<TResult> PostContentAsync<TContent, TResult>(string relativeUrl, TContent content);
-        ValueTask<T> PutContentAsync<T>(string relativeUrl, T content);
-        ValueTask<TResult> PutContentAsync<TContent, TResult>(string relativeUrl, TContent content);
+        ValueTask<T> PostContentAsync<T>(string relativeUrl, T content, string mediaType);
+        
+        ValueTask<TResult> PostContentAsync<TContent, TResult>(
+            string relativeUrl, 
+            TContent content,
+            string mediaType);
+        
+        ValueTask<T> PutContentAsync<T>(string relativeUrl, T content, string mediaType);
+        
+        ValueTask<TResult> PutContentAsync<TContent, TResult>(
+            string relativeUrl, 
+            TContent content,
+            string mediaType);
+        
         ValueTask<T> PutContentAsync<T>(string relativeUrl);
         ValueTask DeleteContentAsync(string relativeUrl);
         ValueTask<T> DeleteContentAsync<T>(string relativeUrl);

--- a/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
@@ -12,10 +12,20 @@ namespace RESTFulSense.Clients
     {
         ValueTask<T> GetContentAsync<T>(string relativeUrl);
         ValueTask<string> GetContentStringAsync(string relativeUrl);
-        ValueTask<T> PostContentAsync<T>(string relativeUrl, T content);
-        ValueTask<TResult> PostContentAsync<TContent, TResult>(string relativeUrl, TContent content);
-        ValueTask<T> PutContentAsync<T>(string relativeUrl, T content);
-        ValueTask<TResult> PutContentAsync<TContent, TResult>(string relativeUrl, TContent content);
+        ValueTask<T> PostContentAsync<T>(string relativeUrl, T content, string mediaType);
+        
+        ValueTask<TResult> PostContentAsync<TContent, TResult>(
+            string relativeUrl, 
+            TContent content, 
+            string mediaType);
+        
+        ValueTask<T> PutContentAsync<T>(string relativeUrl, T content, string mediaType);
+        
+        ValueTask<TResult> PutContentAsync<TContent, TResult>(
+            string relativeUrl, 
+            TContent content,
+            string mediaType);
+        
         ValueTask<T> PutContentAsync<T>(string relativeUrl);
         ValueTask DeleteContentAsync(string relativeUrl);
         ValueTask<T> DeleteContentAsync<T>(string relativeUrl);

--- a/RESTFulSense/Clients/RESTFulApiClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiClient.cs
@@ -25,12 +25,20 @@ namespace RESTFulSense.Clients
         public async ValueTask<string> GetContentStringAsync(string relativeUrl) =>
             await GetStringAsync(relativeUrl);
 
-        public ValueTask<T> PostContentAsync<T>(string relativeUrl, T content) =>
-            PostContentAsync<T, T>(relativeUrl, content);
-
-        public async ValueTask<TResult> PostContentAsync<TContent, TResult>(string relativeUrl, TContent content)
+        public ValueTask<T> PostContentAsync<T>(
+            string relativeUrl, 
+            T content, 
+            string mediaType = "text/json")
         {
-            StringContent contentString = StringifyJsonifyContent(content);
+            return PostContentAsync<T, T>(relativeUrl, content, mediaType);
+        }
+
+        public async ValueTask<TResult> PostContentAsync<TContent, TResult>(
+            string relativeUrl, 
+            TContent content,
+            string mediaType = "text/json")
+        {
+            StringContent contentString = StringifyJsonifyContent(content, mediaType);
 
             HttpResponseMessage responseMessage =
                await PostAsync(relativeUrl, contentString);
@@ -40,9 +48,12 @@ namespace RESTFulSense.Clients
             return await DeserializeResponseContent<TResult>(responseMessage);
         }
 
-        public async ValueTask<T> PutContentAsync<T>(string relativeUrl, T content)
+        public async ValueTask<T> PutContentAsync<T>(
+            string relativeUrl, 
+            T content,
+            string mediaType = "text/json")
         {
-            StringContent contentString = StringifyJsonifyContent(content);
+            StringContent contentString = StringifyJsonifyContent(content, mediaType);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString);
@@ -52,9 +63,12 @@ namespace RESTFulSense.Clients
             return await DeserializeResponseContent<T>(responseMessage);
         }
 
-        public async ValueTask<TResult> PutContentAsync<TContent, TResult>(string relativeUrl, TContent content)
+        public async ValueTask<TResult> PutContentAsync<TContent, TResult>(
+            string relativeUrl, 
+            TContent content,
+            string mediaType)
         {
-            StringContent contentString = StringifyJsonifyContent(content);
+            StringContent contentString = StringifyJsonifyContent(content, mediaType);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString);
@@ -95,12 +109,15 @@ namespace RESTFulSense.Clients
             return JsonConvert.DeserializeObject<T>(responseString);
         }
 
-        private static StringContent StringifyJsonifyContent<T>(T content)
+        private static StringContent StringifyJsonifyContent<T>(T content, string mediaType)
         {
             string serializedRestrictionRequest = JsonConvert.SerializeObject(content);
 
             var contentString =
-                new StringContent(serializedRestrictionRequest, Encoding.UTF8, "text/json");
+                new StringContent(
+                    content: serializedRestrictionRequest,
+                    encoding: Encoding.UTF8,
+                    mediaType);
 
             return contentString;
         }

--- a/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
@@ -32,12 +32,15 @@ namespace RESTFulSense.Clients
         public async ValueTask<string> GetContentStringAsync(string relativeUrl) =>
             await this.httpClient.GetStringAsync(relativeUrl);
 
-        public ValueTask<T> PostContentAsync<T>(string relativeUrl, T content) =>
-            PostContentAsync<T, T>(relativeUrl, content);
+        public ValueTask<T> PostContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json") =>
+            PostContentAsync<T, T>(relativeUrl, content, mediaType);
 
-        public async ValueTask<TResult> PostContentAsync<TContent, TResult>(string relativeUrl, TContent content)
+        public async ValueTask<TResult> PostContentAsync<TContent, TResult>(
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json")
         {
-            StringContent contentString = StringifyJsonifyContent(content);
+            StringContent contentString = StringifyJsonifyContent(content, mediaType);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PostAsync(relativeUrl, contentString);
@@ -47,9 +50,9 @@ namespace RESTFulSense.Clients
             return await DeserializeResponseContent<TResult>(responseMessage);
         }
 
-        public async ValueTask<T> PutContentAsync<T>(string relativeUrl, T content)
+        public async ValueTask<T> PutContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json")
         {
-            StringContent contentString = StringifyJsonifyContent(content);
+            StringContent contentString = StringifyJsonifyContent(content, mediaType);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString);
@@ -59,9 +62,12 @@ namespace RESTFulSense.Clients
             return await DeserializeResponseContent<T>(responseMessage);
         }
 
-        public async ValueTask<TResult> PutContentAsync<TContent, TResult>(string relativeUrl, TContent content)
+        public async ValueTask<TResult> PutContentAsync<TContent, TResult>(
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json")
         {
-            StringContent contentString = StringifyJsonifyContent(content);
+            StringContent contentString = StringifyJsonifyContent(content, mediaType);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString);
@@ -106,12 +112,15 @@ namespace RESTFulSense.Clients
             return JsonConvert.DeserializeObject<T>(responseString);
         }
 
-        private static StringContent StringifyJsonifyContent<T>(T content)
+        private static StringContent StringifyJsonifyContent<T>(T content, string mediaType)
         {
             string serializedRestrictionRequest = JsonConvert.SerializeObject(content);
 
             var contentString =
-                new StringContent(serializedRestrictionRequest, Encoding.UTF8, "text/json");
+                new StringContent(
+                    content: serializedRestrictionRequest,
+                    encoding: Encoding.UTF8,
+                    mediaType);
 
             return contentString;
         }


### PR DESCRIPTION
RESTFulSense can now support different media types in the `POST` and `PUT` actions as follows:

```csharp
       ValueTask<T> PostContentAsync<T>(string relativeUrl, T content, string mediaType);
        
       ValueTask<TResult> PostContentAsync<TContent, TResult>(
            string relativeUrl, 
            TContent content, 
            string mediaType);
        
        ValueTask<T> PutContentAsync<T>(string relativeUrl, T content, string mediaType);
        
        ValueTask<TResult> PutContentAsync<TContent, TResult>(
            string relativeUrl, 
            TContent content,
            string mediaType);
```