### PR TITLE
MAJORFIX: Ensuring errors is serialized as per serialization policy defined

### DIFF
--- a/RESTFulSense.Tests/Controllers/RESTFulControllerTests.cs
+++ b/RESTFulSense.Tests/Controllers/RESTFulControllerTests.cs
@@ -4,6 +4,11 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
 using RESTFulSense.Controllers;
 using Tynamix.ObjectFiller;
 
@@ -14,7 +19,64 @@ namespace RESTFulSense.Tests.Controllers
         private readonly RESTFulController restfulController;
 
         public RESTFulControllerTests() =>
-            this.restfulController = new RESTFulController();
+            this.restfulController = new RESTFulController(new JsonSerializerOptions());
+
+        public static IEnumerable<object[]> SerializationCases()
+        {
+            JsonSerializerOptions jsonSerializerSettingsPascal = new JsonSerializerOptions();
+
+            JsonSerializerOptions jsonSerializerSettingsCamel = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+
+            return new List<object[]>
+            {
+                new object[] { jsonSerializerSettingsPascal },
+                new object[] { jsonSerializerSettingsCamel }
+            };
+        }
+
+        private void SetupInputAndExpectedCriteria(
+            Dictionary<string, List<string>> randomDictionary,
+            Exception inputException,
+            ValidationProblemDetails expectedProblemDetail)
+        {
+            this.SetupInputAndExpectedCriteria(
+                randomDictionary,
+                inputException,
+                expectedProblemDetail,
+                jsonSerializerOptions: new JsonSerializerOptions());
+        }
+
+        private void SetupInputAndExpectedCriteria(
+            Dictionary<string, List<string>> randomDictionary,
+            Exception inputException,
+            ValidationProblemDetails expectedProblemDetail,
+            JsonSerializerOptions jsonSerializerOptions)
+        {
+            foreach (KeyValuePair<string, List<string>> item in randomDictionary)
+            {
+                inputException.Data.Add(item.Key, item.Value);
+
+                string serializedKey = ApplySerialization(
+                    error: new DictionaryEntry(item.Key, item.Value),
+                    jsonSerializerOptions: jsonSerializerOptions);
+
+                expectedProblemDetail.Errors.Add(
+                    key: serializedKey,
+                    value: item.Value.ToArray());
+            }
+        }
+
+        private static string ApplySerialization(DictionaryEntry error, JsonSerializerOptions jsonSerializerOptions)
+        {
+            return jsonSerializerOptions.PropertyNamingPolicy == JsonNamingPolicy.CamelCase
+                ? error.Key.ToString().Substring(0, 1).ToLower() + error.Key.ToString().Substring(1)
+                : error.Key.ToString().Substring(0, 1).ToUpper() + error.Key.ToString().Substring(1);
+        }
 
         private static string GetRandomMessage() =>
             new MnemonicString().GetValue();

--- a/RESTFulSense.Tests/Controllers/RESTFulControllerTests.cs
+++ b/RESTFulSense.Tests/Controllers/RESTFulControllerTests.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using RESTFulSense.Controllers;
 using Tynamix.ObjectFiller;
+using Xunit;
 
 namespace RESTFulSense.Tests.Controllers
 {
@@ -21,23 +22,17 @@ namespace RESTFulSense.Tests.Controllers
         public RESTFulControllerTests() =>
             this.restfulController = new RESTFulController(new JsonSerializerOptions());
 
-        public static IEnumerable<object[]> SerializationCases()
+        public static TheoryData<JsonSerializerOptions> SerializationCases => new()
         {
-            JsonSerializerOptions jsonSerializerSettingsPascal = new JsonSerializerOptions();
-
-            JsonSerializerOptions jsonSerializerSettingsCamel = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
-                WriteIndented = true
-            };
-
-            return new List<object[]>
-            {
-                new object[] { jsonSerializerSettingsPascal },
-                new object[] { jsonSerializerSettingsCamel }
-            };
-        }
+            { new JsonSerializerOptions() },
+            { new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = true
+                }
+            }
+        };
 
         private void SetupInputAndExpectedCriteria(
             Dictionary<string, List<string>> randomDictionary,

--- a/RESTFulSense/Controllers/RESTFulController.cs
+++ b/RESTFulSense/Controllers/RESTFulController.cs
@@ -23,6 +23,11 @@ namespace RESTFulSense.Controllers
         public RESTFulController(JsonSerializerOptions jsonSerializerOptions = null)
         {
             this.jsonSerializerOptions = jsonSerializerOptions ?? new JsonSerializerOptions();
+
+            if (this.jsonSerializerOptions.DictionaryKeyPolicy == null)
+            {
+                this.jsonSerializerOptions.DictionaryKeyPolicy = this.jsonSerializerOptions.PropertyNamingPolicy;
+            }
         }
 
         [NonAction]

--- a/RESTFulSense/Controllers/RESTFulController.cs
+++ b/RESTFulSense/Controllers/RESTFulController.cs
@@ -7,6 +7,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using RESTFulSense.Models;
@@ -15,6 +18,13 @@ namespace RESTFulSense.Controllers
 {
     public class RESTFulController : ControllerBase, IRESTFulController
     {
+        private readonly JsonSerializerOptions jsonSerializerOptions;
+
+        public RESTFulController(JsonSerializerOptions jsonSerializerOptions = null)
+        {
+            this.jsonSerializerOptions = jsonSerializerOptions ?? new JsonSerializerOptions();
+        }
+
         [NonAction]
         public CreatedObjectResult Created(object value) =>
             new CreatedObjectResult(value);
@@ -717,16 +727,34 @@ namespace RESTFulSense.Controllers
             return new NetworkAuthenticationRequiredObjectResult(problemDetail);
         }
 
-        private static void MapExceptionDataToProblemDetail(
+        private void MapExceptionDataToProblemDetail(
             Exception exception,
             ValidationProblemDetails problemDetail)
         {
             foreach (DictionaryEntry error in exception.Data)
             {
+                string errorKey = ApplySerialization(error, jsonSerializerOptions);
+
                 problemDetail.Errors.Add(
-                    key: error.Key.ToString(),
+                    key: errorKey,
                     value: ((List<string>)error.Value)?.ToArray());
             }
+        }
+
+        private static string ApplySerialization(DictionaryEntry error, JsonSerializerOptions jsonSerializerOptions)
+        {
+            IDictionary<string, Object> interimObject = new ExpandoObject();
+            interimObject.Add(error.Key.ToString(), error.Value);
+
+            string serialisedInterimObject =
+                JsonSerializer.Serialize(interimObject, jsonSerializerOptions);
+
+            var deserializedError =
+                JsonSerializer.Deserialize<IDictionary<string, Object>>(
+                    serialisedInterimObject,
+                    jsonSerializerOptions);
+
+            return deserializedError.Keys.First();
         }
     }
 }

--- a/RESTFulSense/RESTFulSense.csproj
+++ b/RESTFulSense/RESTFulSense.csproj
@@ -28,6 +28,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="System.Text.Json" Version="6.0.6" />
 		<PackageReference Include="Xeption" Version="1.7.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
### PROBLEM
Keys in the errors collection is not serialized as per the configuration in startup.cs
![image](https://user-images.githubusercontent.com/797750/191062300-ec038b13-d9df-4033-a2d0-eb22617d6479.png)

### SOLUTION
Extend `RESTFulController` to allow DI of `JsonSerializerOptions`
```
public RESTFulController(JsonSerializerOptions jsonSerializerOptions = null)
{
        this.jsonSerializerOptions = jsonSerializerOptions ?? new JsonSerializerOptions();
}
```
Having a default property of `null` would mean that you are still backwards compatible and that no controller signatures would need changing (although it would mask the issue) while controllers that require the serialization could be changed from:
```
public PostsController(IPostService postService) =>
            this.postService = postService;
```
**TO**
```
public PostsController(
            IPostService postService,
            JsonSerializerOptions jsonSerializerOptions)
            : base(jsonSerializerOptions) =>
                        this.postService = postService;
```

The following registration also needs to happen on your startup.cs
```
public void ConfigureServices(IServiceCollection services)
{
            services.AddLogging();
            JsonNamingPolicy jsonNamingPolicy = JsonNamingPolicy.CamelCase;

            services.AddControllers().AddJsonOptions(options =>
                        {
                                    options.JsonSerializerOptions.PropertyNamingPolicy =
                                                jsonNamingPolicy;

                                    options.JsonSerializerOptions.DictionaryKeyPolicy =
                                                jsonNamingPolicy;
                        });

                        services.AddSingleton(new JsonSerializerOptions
                                    {
                                                PropertyNamingPolicy = jsonNamingPolicy,
                                                DictionaryKeyPolicy = jsonNamingPolicy,
                                    });
            . . .
}
```
### IMPORTANT 
- The addition of the `services.AddSingleton(new JsonSerializerOptions{...});`  is required for DI on the controller. 
- **`DictionaryKeyPolicy`** is required for the serialization of the errors dictionary.

These will then give an expected outcome of:
![image](https://user-images.githubusercontent.com/797750/191065907-d2e252d3-013f-4dbb-a092-55696b1b4daf.png)

