### PR TITLE
MINOR FIX: Ignore Default Values Parameter for Post and Put

### DIFF
--- a/RESTFulSense.WebAssembly/Clients/IRESTFulApiClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/IRESTFulApiClient.cs
@@ -18,48 +18,60 @@ namespace RESTFulSense.WebAssembly.Clients
         public ValueTask PostContentWithNoResponseAsync<T>(
             string relativeUrl,
             T content,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         public ValueTask PostContentWithNoResponseAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
-        ValueTask<T> PostContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json");
+        ValueTask<T> PostContentAsync<T>(
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(
             string relativeUrl,
             T content,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(string relativeUrl);
         ValueTask<T> PutContentAsync<T>(string relativeUrl, CancellationToken cancellationToken);

--- a/RESTFulSense.WebAssembly/Clients/IRESTFulApiFactoryClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/IRESTFulApiFactoryClient.cs
@@ -18,45 +18,60 @@ namespace RESTFulSense.WebAssembly.Clients
         public ValueTask PostContentWithNoResponseAsync<T>(
             string relativeUrl,
             T content,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         public ValueTask PostContentWithNoResponseAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
-        ValueTask<T> PostContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json");
+        ValueTask<T> PostContentAsync<T>(
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
-        ValueTask<T> PutContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json");
+        ValueTask<T> PutContentAsync<T>(
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json");
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(string relativeUrl);
         ValueTask<T> PutContentAsync<T>(string relativeUrl, CancellationToken cancellationToken);

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.Conversions.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.Conversions.cs
@@ -65,6 +65,7 @@ namespace RESTFulSense.WebAssembly.Clients
         {
             DefaultValueHandling defaultValueHandling = ignoreDefaultValues ? DefaultValueHandling.Ignore : DefaultValueHandling.Include;
             var jsonSerializerSettings = new JsonSerializerSettings { DefaultValueHandling = defaultValueHandling };
+
             return jsonSerializerSettings;
         }
     }

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.Conversions.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.Conversions.cs
@@ -14,12 +14,12 @@ namespace RESTFulSense.WebAssembly.Clients
 {
     public partial class RESTFulApiClient
     {
-        private static HttpContent ConvertToHttpContent<T>(T content, string mediaType)
+        private static HttpContent ConvertToHttpContent<T>(T content, string mediaType, bool ignoreDefaultValues)
         {
             return mediaType switch
             {
-                "text/json" => ConvertToJsonStringContent(content, mediaType),
-                "application/json" => ConvertToJsonStringContent(content, mediaType),
+                "text/json" => ConvertToJsonStringContent(content, mediaType, ignoreDefaultValues),
+                "application/json" => ConvertToJsonStringContent(content, mediaType, ignoreDefaultValues),
                 "text/plain" => ConvertToStringContent(content, mediaType),
                 "application/octet-stream" => ConvertToStreamContent(content as Stream, mediaType),
                 _ => ConvertToStringContent(content, mediaType)
@@ -34,9 +34,14 @@ namespace RESTFulSense.WebAssembly.Clients
                 mediaType);
         }
 
-        private static StringContent ConvertToJsonStringContent<T>(T content, string mediaType)
+        private static StringContent ConvertToJsonStringContent<T>(T content, string mediaType, bool ignoreDefaultValues)
         {
-            string serializedRestrictionRequest = JsonConvert.SerializeObject(content);
+            JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings(ignoreDefaultValues);
+
+            string serializedRestrictionRequest = JsonConvert.SerializeObject(
+                content,
+                formatting: Formatting.None,
+                settings: jsonSerializerSettings);
 
             var contentString =
                 new StringContent(
@@ -56,5 +61,11 @@ namespace RESTFulSense.WebAssembly.Clients
             return contentStream;
         }
 
+        private static JsonSerializerSettings CreateJsonSerializerSettings(bool ignoreDefaultValues)
+        {
+            DefaultValueHandling defaultValueHandling = ignoreDefaultValues ? DefaultValueHandling.Ignore : DefaultValueHandling.Include;
+            var jsonSerializerSettings = new JsonSerializerSettings { DefaultValueHandling = defaultValueHandling };
+            return jsonSerializerSettings;
+        }
     }
 }

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.cs
@@ -36,9 +36,11 @@ namespace RESTFulSense.WebAssembly.Clients
         public async ValueTask PostContentWithNoResponseAsync<T>(
             string relativeUrl,
             T content,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString =
+                ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                 await PostAsync(relativeUrl, contentString);
@@ -50,9 +52,11 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString =
+                ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                 await PostAsync(relativeUrl, contentString, cancellationToken);
@@ -63,7 +67,8 @@ namespace RESTFulSense.WebAssembly.Clients
         public ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
             return PostContentAsync<T, T>(relativeUrl, content, mediaType);
         }
@@ -72,7 +77,8 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
             return PostContentAsync<T, T>(relativeUrl, content, cancellationToken, mediaType);
         }
@@ -80,9 +86,11 @@ namespace RESTFulSense.WebAssembly.Clients
         public async ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString =
+                ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PostAsync(relativeUrl, contentString);
@@ -96,9 +104,10 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PostAsync(relativeUrl, contentString, cancellationToken);
@@ -111,9 +120,10 @@ namespace RESTFulSense.WebAssembly.Clients
         public async ValueTask<T> PutContentAsync<T>(
             string relativeUrl,
             T content,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString);
@@ -127,9 +137,10 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString, cancellationToken);
@@ -142,9 +153,10 @@ namespace RESTFulSense.WebAssembly.Clients
         public async ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString);
@@ -158,9 +170,10 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString, cancellationToken);

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.Conversions.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.Conversions.cs
@@ -14,12 +14,12 @@ namespace RESTFulSense.WebAssembly.Clients
 {
     public partial class RESTFulApiFactoryClient
     {
-        private static HttpContent ConvertToHttpContent<T>(T content, string mediaType)
+        private static HttpContent ConvertToHttpContent<T>(T content, string mediaType, bool ignoreDefaultValues)
         {
             return mediaType switch
             {
-                "text/json" => ConvertToJsonStringContent(content, mediaType),
-                "application/json" => ConvertToJsonStringContent(content, mediaType),
+                "text/json" => ConvertToJsonStringContent(content, mediaType, ignoreDefaultValues),
+                "application/json" => ConvertToJsonStringContent(content, mediaType, ignoreDefaultValues),
                 "text/plain" => ConvertToStringContent(content, mediaType),
                 "application/octet-stream" => ConvertToStreamContent(content as Stream, mediaType),
                 _ => ConvertToStringContent(content, mediaType)
@@ -34,9 +34,14 @@ namespace RESTFulSense.WebAssembly.Clients
                 mediaType);
         }
 
-        private static StringContent ConvertToJsonStringContent<T>(T content, string mediaType)
+        private static StringContent ConvertToJsonStringContent<T>(T content, string mediaType, bool ignoreDefaultValues)
         {
-            string serializedRestrictionRequest = JsonConvert.SerializeObject(content);
+            JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings(ignoreDefaultValues);
+
+            string serializedRestrictionRequest = JsonConvert.SerializeObject(
+                content,
+                formatting: Formatting.None,
+                settings: jsonSerializerSettings);
 
             var contentString =
                 new StringContent(
@@ -54,6 +59,13 @@ namespace RESTFulSense.WebAssembly.Clients
             contentStream.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
             return contentStream;
+        }
+
+        private static JsonSerializerSettings CreateJsonSerializerSettings(bool ignoreDefaultValues)
+        {
+            DefaultValueHandling defaultValueHandling = ignoreDefaultValues ? DefaultValueHandling.Ignore : DefaultValueHandling.Include;
+            var jsonSerializerSettings = new JsonSerializerSettings { DefaultValueHandling = defaultValueHandling };
+            return jsonSerializerSettings;
         }
     }
 }

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.cs
@@ -48,9 +48,10 @@ namespace RESTFulSense.WebAssembly.Clients
         public async ValueTask PostContentWithNoResponseAsync<T>(
             string relativeUrl,
             T content,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                 await this.httpClient.PostAsync(relativeUrl, contentString);
@@ -62,9 +63,10 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                 await this.httpClient.PostAsync(relativeUrl, contentString, cancellationToken);
@@ -72,22 +74,28 @@ namespace RESTFulSense.WebAssembly.Clients
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
         }
 
-        public ValueTask<T> PostContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json") =>
-            PostContentAsync<T, T>(relativeUrl, content, mediaType);
+        public ValueTask<T> PostContentAsync<T>(
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false) =>
+            PostContentAsync<T, T>(relativeUrl, content, mediaType, ignoreDefaultValues);
 
         public ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json") =>
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false) =>
             PostContentAsync<T, T>(relativeUrl, content, cancellationToken, mediaType);
 
         public async ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PostAsync(relativeUrl, contentString);
@@ -101,9 +109,10 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PostAsync(relativeUrl, contentString, cancellationToken);
@@ -113,9 +122,13 @@ namespace RESTFulSense.WebAssembly.Clients
             return await DeserializeResponseContent<TResult>(responseMessage);
         }
 
-        public async ValueTask<T> PutContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json")
+        public async ValueTask<T> PutContentAsync<T>(
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString);
@@ -129,9 +142,10 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString, cancellationToken);
@@ -144,9 +158,10 @@ namespace RESTFulSense.WebAssembly.Clients
         public async ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString);
@@ -160,9 +175,10 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
-            string mediaType = "text/json")
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString, cancellationToken);

--- a/RESTFulSense/Clients/IRESTFulApiClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiClient.cs
@@ -19,59 +19,59 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         public ValueTask PostContentWithNoResponseAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(string relativeUrl);
         ValueTask<T> PutContentAsync<T>(string relativeUrl, CancellationToken cancellationToken);

--- a/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
@@ -19,59 +19,59 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         public ValueTask PostContentWithNoResponseAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<TResult> PutContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false);
+            bool ignoreDefaultValues = false);
 
         ValueTask<T> PutContentAsync<T>(string relativeUrl);
         ValueTask<T> PutContentAsync<T>(string relativeUrl, CancellationToken cancellationToken);

--- a/RESTFulSense/Clients/RESTFulApiClient.Conversions.cs
+++ b/RESTFulSense/Clients/RESTFulApiClient.Conversions.cs
@@ -14,12 +14,12 @@ namespace RESTFulSense.Clients
 {
     public partial class RESTFulApiClient
     {
-        private static HttpContent ConvertToHttpContent<T>(T content, string mediaType, bool ignoreNulls)
+        private static HttpContent ConvertToHttpContent<T>(T content, string mediaType, bool ignoreDefaultValues)
         {
             return mediaType switch
             {
-                "text/json" => ConvertToJsonStringContent(content, mediaType, ignoreNulls),
-                "application/json" => ConvertToJsonStringContent(content, mediaType, ignoreNulls),
+                "text/json" => ConvertToJsonStringContent(content, mediaType, ignoreDefaultValues),
+                "application/json" => ConvertToJsonStringContent(content, mediaType, ignoreDefaultValues),
                 "text/plain" => ConvertToStringContent(content, mediaType),
                 "application/octet-stream" => ConvertToStreamContent(content as Stream, mediaType),
                 _ => ConvertToStringContent(content, mediaType)
@@ -34,9 +34,9 @@ namespace RESTFulSense.Clients
                 mediaType);
         }
 
-        private static StringContent ConvertToJsonStringContent<T>(T content, string mediaType, bool ignoreNulls)
+        private static StringContent ConvertToJsonStringContent<T>(T content, string mediaType, bool ignoreDefaultValues)
         {
-            JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings(ignoreNulls);
+            JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings(ignoreDefaultValues);
 
             string serializedRestrictionRequest = JsonConvert.SerializeObject(
                 content,
@@ -61,10 +61,10 @@ namespace RESTFulSense.Clients
             return contentStream;
         }
 
-        private static JsonSerializerSettings CreateJsonSerializerSettings(bool ignoreNullValues)
+        private static JsonSerializerSettings CreateJsonSerializerSettings(bool ignoreDefaultValues)
         {
-            var defaultValueHandling = ignoreNullValues ? DefaultValueHandling.Ignore : DefaultValueHandling.Include;
-            var jsonSerializerSettings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore };
+            DefaultValueHandling defaultValueHandling = ignoreDefaultValues ? DefaultValueHandling.Ignore : DefaultValueHandling.Include;
+            var jsonSerializerSettings = new JsonSerializerSettings { DefaultValueHandling = defaultValueHandling };
             return jsonSerializerSettings;
         }
     }

--- a/RESTFulSense/Clients/RESTFulApiClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiClient.cs
@@ -84,8 +84,7 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
-            HttpResponseMessage responseMessage =
-               await PostAsync(relativeUrl, contentString);
+            HttpResponseMessage responseMessage = await PostAsync(relativeUrl, contentString);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 

--- a/RESTFulSense/Clients/RESTFulApiClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiClient.cs
@@ -37,9 +37,9 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                 await PostAsync(relativeUrl, contentString);
@@ -52,9 +52,9 @@ namespace RESTFulSense.Clients
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                 await PostAsync(relativeUrl, contentString, cancellationToken);
@@ -66,23 +66,23 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false) => PostContentAsync<T, T>(relativeUrl, content, mediaType, ignoreNulls);
+            bool ignoreDefaultValues = false) => PostContentAsync<T, T>(relativeUrl, content, mediaType, ignoreDefaultValues);
 
         public ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false) =>
-            PostContentAsync<T, T>(relativeUrl, content, cancellationToken, mediaType, ignoreNulls);
+            bool ignoreDefaultValues = false) =>
+            PostContentAsync<T, T>(relativeUrl, content, cancellationToken, mediaType, ignoreDefaultValues);
 
         public async ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PostAsync(relativeUrl, contentString);
@@ -97,9 +97,9 @@ namespace RESTFulSense.Clients
             TContent content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PostAsync(relativeUrl, contentString, cancellationToken);
@@ -113,9 +113,9 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString);
@@ -130,9 +130,9 @@ namespace RESTFulSense.Clients
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString, cancellationToken);
@@ -146,9 +146,9 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             TContent content,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString);
@@ -163,9 +163,9 @@ namespace RESTFulSense.Clients
             TContent content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await PutAsync(relativeUrl, contentString, cancellationToken);

--- a/RESTFulSense/Clients/RESTFulApiFactoryClient.Conversions.cs
+++ b/RESTFulSense/Clients/RESTFulApiFactoryClient.Conversions.cs
@@ -4,7 +4,6 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
-using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -15,12 +14,12 @@ namespace RESTFulSense.Clients
 {
     public partial class RESTFulApiFactoryClient
     {
-        private static HttpContent ConvertToHttpContent<T>(T content, string mediaType, bool ignoreNulls)
+        private static HttpContent ConvertToHttpContent<T>(T content, string mediaType, bool ignoreDefaultValues)
         {
             return mediaType switch
             {
-                "text/json" => ConvertToJsonStringContent(content, mediaType, ignoreNulls),
-                "application/json" => ConvertToJsonStringContent(content, mediaType, ignoreNulls),
+                "text/json" => ConvertToJsonStringContent(content, mediaType, ignoreDefaultValues),
+                "application/json" => ConvertToJsonStringContent(content, mediaType, ignoreDefaultValues),
                 "text/plain" => ConvertToStringContent(content, mediaType),
                 "application/octet-stream" => ConvertToStreamContent(content as Stream, mediaType),
                 _ => ConvertToStringContent(content, mediaType)
@@ -35,9 +34,9 @@ namespace RESTFulSense.Clients
                 mediaType);
         }
 
-        private static StringContent ConvertToJsonStringContent<T>(T content, string mediaType, bool ignoreNulls)
+        private static StringContent ConvertToJsonStringContent<T>(T content, string mediaType, bool ignoreDefaultValues)
         {
-            JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings(ignoreNulls);
+            JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings(ignoreDefaultValues);
 
             string serializedRestrictionRequest = JsonConvert.SerializeObject(
                 content,
@@ -62,10 +61,10 @@ namespace RESTFulSense.Clients
             return contentStream;
         }
 
-        private static JsonSerializerSettings CreateJsonSerializerSettings(bool ignoreNullValues)
+        private static JsonSerializerSettings CreateJsonSerializerSettings(bool ignoreDefaultValues)
         {
-            var defaultValueHandling = ignoreNullValues ? DefaultValueHandling.Ignore : DefaultValueHandling.Include;
-            var jsonSerializerSettings = new JsonSerializerSettings { DefaultValueHandling = DefaultValueHandling.Ignore };
+            var defaultValueHandling = ignoreDefaultValues ? DefaultValueHandling.Ignore : DefaultValueHandling.Include;
+            var jsonSerializerSettings = new JsonSerializerSettings { DefaultValueHandling = defaultValueHandling };
             return jsonSerializerSettings;
         }
     }

--- a/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
@@ -46,9 +46,9 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                 await this.httpClient.PostAsync(relativeUrl, contentString);
@@ -61,9 +61,9 @@ namespace RESTFulSense.Clients
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                 await this.httpClient.PostAsync(relativeUrl, contentString, cancellationToken);
@@ -75,24 +75,24 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             T content,
             string mediaType = "text/json",
-            bool ignoreNulls = false) =>
-            PostContentAsync<T, T>(relativeUrl, content, mediaType, ignoreNulls);
+            bool ignoreDefaultValues = false) =>
+            PostContentAsync<T, T>(relativeUrl, content, mediaType, ignoreDefaultValues);
 
         public ValueTask<T> PostContentAsync<T>(
             string relativeUrl,
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false) =>
-            PostContentAsync<T, T>(relativeUrl, content, cancellationToken, mediaType, ignoreNulls);
+            bool ignoreDefaultValues = false) =>
+            PostContentAsync<T, T>(relativeUrl, content, cancellationToken, mediaType, ignoreDefaultValues);
 
         public async ValueTask<TResult> PostContentAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PostAsync(relativeUrl, contentString);
@@ -107,9 +107,9 @@ namespace RESTFulSense.Clients
             TContent content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PostAsync(relativeUrl, contentString, cancellationToken);
@@ -119,9 +119,9 @@ namespace RESTFulSense.Clients
             return await DeserializeResponseContent<TResult>(responseMessage);
         }
 
-        public async ValueTask<T> PutContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json", bool ignoreNulls = false)
+        public async ValueTask<T> PutContentAsync<T>(string relativeUrl, T content, string mediaType = "text/json", bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString);
@@ -136,9 +136,9 @@ namespace RESTFulSense.Clients
             T content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString, cancellationToken);
@@ -152,9 +152,9 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             TContent content,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString);
@@ -169,9 +169,9 @@ namespace RESTFulSense.Clients
             TContent content,
             CancellationToken cancellationToken,
             string mediaType = "text/json",
-            bool ignoreNulls = false)
+            bool ignoreDefaultValues = false)
         {
-            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreNulls);
+            HttpContent contentString = ConvertToHttpContent(content, mediaType, ignoreDefaultValues);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(relativeUrl, contentString, cancellationToken);


### PR DESCRIPTION
This changes the parameter name the previous version that is new and has a default value.

Ignore nulls is what we spoke about in the discussions.
The Json Serializer setting is for "DefaultValueHandling"
This name better reflects the intent of the parameter.
I have updated both RESTFulSense and RESTFulSense.WebAssembly for aligment. I would recommend a version bump for both and maybe even alignment of the numbers.

Closes #63 