### PR TITLE
MAJOR FIX: Serialize Problem Details

### DIFF
--- a/RESTFulSense.WebAssembly/Models/ValidationProblemDetails.cs
+++ b/RESTFulSense.WebAssembly/Models/ValidationProblemDetails.cs
@@ -17,7 +17,14 @@ namespace RESTFulSense.WebAssembly.Exceptions
         }
 
         public string Title { get; set; }
-        public IDictionary<string, string[]> Errors => Data;
+
+        public IDictionary<string, string[]> Errors
+        {
+            get => Data;
+
+            set => Data = new Dictionary<string, string[]>(value);
+        }
+
         public Dictionary<string, string[]> Data { get; set; }
         public string Type { get; set; }
     }

--- a/RESTFulSense.WebAssembly/Services/ValidationService.cs
+++ b/RESTFulSense.WebAssembly/Services/ValidationService.cs
@@ -293,15 +293,24 @@ namespace RESTFulSense.WebAssembly.Services
             }
         }
 
-        private static bool NotFoundWithNoContent(HttpResponseMessage httpResponseMessage) =>
-            httpResponseMessage.Content.Headers.Contains(name: "Content-Type") == false
-            && httpResponseMessage.StatusCode == HttpStatusCode.NotFound;
+        private static bool NotFoundWithNoContent(HttpResponseMessage httpResponseMessage)
+        {
+            return httpResponseMessage.Content.Headers.Contains(name: "Content-Type")
+             && httpResponseMessage.StatusCode is HttpStatusCode.NotFound;
+        }
 
-        private static ValidationProblemDetails MapToProblemDetails(string content) =>
-            JsonSerializer.Deserialize<ValidationProblemDetails>(content);
+        private static ValidationProblemDetails MapToProblemDetails(string content)
+        {
+            return JsonSerializer.Deserialize<ValidationProblemDetails>(
+                 json: content,
+                 options: new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        }
 
-        private static bool IsProblemDetail(string content) =>
-            content.Contains(value: "\"title\":", StringComparison.OrdinalIgnoreCase) &&
-            content.Contains(value: "\"type\":", StringComparison.OrdinalIgnoreCase);
+        private static bool IsProblemDetail(string content)
+        {
+            return content.Contains(value: "\"title\":", StringComparison.OrdinalIgnoreCase)
+                && content.Contains(value: "\"type\":", StringComparison.OrdinalIgnoreCase);
+        }
+
     }
 }

--- a/RESTFulSense.WebAssembly/Services/ValidationService.cs
+++ b/RESTFulSense.WebAssembly/Services/ValidationService.cs
@@ -295,7 +295,7 @@ namespace RESTFulSense.WebAssembly.Services
 
         private static bool NotFoundWithNoContent(HttpResponseMessage httpResponseMessage)
         {
-            return httpResponseMessage.Content.Headers.Contains(name: "Content-Type")
+            return httpResponseMessage.Content.Headers.Contains(name: "Content-Type") is false
              && httpResponseMessage.StatusCode is HttpStatusCode.NotFound;
         }
 


### PR DESCRIPTION
## Background
When we are handling bad request, RESTFulSense.WebAssembly is not giving us the errors and proper message:

![image](https://github.com/hassanhabib/RESTFulSense/assets/52498074/be7cc50d-ba3c-44ee-b5f2-222689d351a9)
![image](https://github.com/hassanhabib/RESTFulSense/assets/52498074/c69f83fa-63f0-4432-903e-88b9bce4ec01)

## Expectation
These are what we are getting, while I was expecting:
![image](https://github.com/hassanhabib/RESTFulSense/assets/52498074/6210fbdd-76b9-41b7-bd6f-66356b131399)


## Solution
I fixed the model and added serialization options in case it is ignoring based on the casing of the API response