### PR TITLE
CLIENTS: Execute Any API Call w/ Validations

### DIFF
--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulApiClientTests.ExecuteHttpCall.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulApiClientTests.ExecuteHttpCall.cs
@@ -1,0 +1,49 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RESTFulSense.Tests.Acceptance.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace RESTFulSense.Tests.Acceptance.Tests
+{
+    public partial class RestfulApiClientTests
+    {
+
+        [Fact]
+        private async Task ShouldExecuteHttpCallAsync()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity expectedTEntity = randomTEntity;
+            var httpClient = new HttpClient();
+            httpClient.BaseAddress = new Uri(this.wiremockServer.Urls[0]);
+
+            this.wiremockServer.Given(Request.Create()
+                .WithPath(relativeUrl)
+                .UsingGet())
+                    .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBodyAsJson(expectedTEntity));
+
+            // when
+            HttpResponseMessage httpResponseMessage =
+                await this.restfulApiClient.ExecuteHttpCallAsync(
+                    httpClient.GetAsync("/tests"));
+
+            TEntity actualTEntityEntity =
+                JsonConvert.DeserializeObject<TEntity>(
+                    await httpResponseMessage.Content.ReadAsStringAsync());
+
+            // then
+            actualTEntityEntity.Should().BeEquivalentTo(expectedTEntity);
+        }
+    }
+}

--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulApiClientTests.PostContent.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulApiClientTests.PostContent.cs
@@ -19,7 +19,7 @@ namespace RESTFulSense.Tests.Acceptance.Tests
     {
 
         [Fact]
-        private async Task ShouldPostContentWithNoResponseAndDeserializeContentAsync()
+        private void ShouldPostContentWithNoResponseAndDeserializeContent()
         {
             // given
             TEntity randomTEntity = GetRandomTEntity();

--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.ExecuteHttpCall.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.ExecuteHttpCall.cs
@@ -1,0 +1,48 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RESTFulSense.Tests.Acceptance.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace RESTFulSense.Tests.Acceptance.Tests
+{
+    public partial class RestfulSenseApiFactoryTests
+    {
+        [Fact]
+        private async Task ShouldExecuteHttpCallAsync()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity expectedTEntity = randomTEntity;
+            var httpClient = new HttpClient();
+            httpClient.BaseAddress = new Uri(this.wiremockServer.Urls[0]);
+
+            this.wiremockServer.Given(Request.Create()
+                .WithPath(relativeUrl)
+                .UsingGet())
+                    .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBodyAsJson(expectedTEntity));
+
+            // when
+            HttpResponseMessage httpResponseMessage =
+                await this.factoryClient.ExecuteHttpCallAsync(
+                    httpClient.GetAsync("/tests"));
+
+            TEntity actualTEntityEntity =
+                JsonConvert.DeserializeObject<TEntity>(
+                    await httpResponseMessage.Content.ReadAsStringAsync());
+
+            // then
+            actualTEntityEntity.Should().BeEquivalentTo(expectedTEntity);
+        }
+    }
+}

--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.PostContent.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.PostContent.cs
@@ -53,7 +53,7 @@ namespace RESTFulSense.Tests.Acceptance.Tests
         }
 
         [Fact]
-        private async Task ShouldPostContentWithNoResponseAndDeserializeContentAsync()
+        private void ShouldPostContentWithNoResponseAndDeserializeContent()
         {
             // given
             TEntity randomTEntity = GetRandomTEntity();

--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.PutContent.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.PutContent.cs
@@ -5,7 +5,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Newtonsoft.Json;
 using RESTFulSense.Tests.Acceptance.Models;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;

--- a/RESTFulSense.Tests/Services/Foundations/Forms/FormServiceTests.Validations.AddByteArrays.cs
+++ b/RESTFulSense.Tests/Services/Foundations/Forms/FormServiceTests.Validations.AddByteArrays.cs
@@ -23,7 +23,7 @@ namespace RESTFulSense.Tests.Services.Foundations.Forms
             // given
             MultipartFormDataContent nullMultipartFormDataContent =
                 CreateNullMultipartFormDataContent();
-            
+
             byte[] nullContent = null;
             string invalidName = invalidInput;
 
@@ -78,7 +78,7 @@ namespace RESTFulSense.Tests.Services.Foundations.Forms
             // given
             MultipartFormDataContent nullMultipartFormDataContent =
                 CreateNullMultipartFormDataContent();
-            
+
             byte[] nullContent = null;
             string invalidName = invalidInput;
             string invalidFileName = invalidInput;

--- a/RESTFulSense.Tests/Services/Foundations/Forms/FormServiceTests.Validations.AddStreams.cs
+++ b/RESTFulSense.Tests/Services/Foundations/Forms/FormServiceTests.Validations.AddStreams.cs
@@ -24,7 +24,7 @@ namespace RESTFulSense.Tests.Services.Foundations.Forms
             // given
             MultipartFormDataContent nullMultipartFormDataContent =
                 CreateNullMultipartFormDataContent();
-            
+
             Stream nullContent = null;
             string invalidName = invalidInput;
 
@@ -79,7 +79,7 @@ namespace RESTFulSense.Tests.Services.Foundations.Forms
             // given
             MultipartFormDataContent nullMultipartFormDataContent =
                 CreateNullMultipartFormDataContent();
-            
+
             Stream nullContent = null;
             string invalidName = invalidInput;
             string invalidFileName = invalidInput;

--- a/RESTFulSense.Tests/Services/Foundations/Forms/FormServiceTests.Validations.AddStrings.cs
+++ b/RESTFulSense.Tests/Services/Foundations/Forms/FormServiceTests.Validations.AddStrings.cs
@@ -22,7 +22,7 @@ namespace RESTFulSense.Tests.Services.Foundations.Forms
             // given
             MultipartFormDataContent nullMultipartFormDataContent =
                 CreateNullMultipartFormDataContent();
-            
+
             string invalidContent = invalidInput;
             string invalidName = invalidInput;
 

--- a/RESTFulSense.Tests/Services/Foundations/Properties/PropertyServiceTests.Exceptions.Retrieve.cs
+++ b/RESTFulSense.Tests/Services/Foundations/Properties/PropertyServiceTests.Exceptions.Retrieve.cs
@@ -23,7 +23,7 @@ namespace RESTFulSense.Tests.Services.Properties
                 new FailedPropertyServiceException(
                      message: "Failed Property Service Exception occurred, please contact support for assistance.",
                     innerException: someException);
-            
+
             var expectedPropertyServiceException =
                 new PropertyServiceException(
                     message: "Property service error occurred, contact support.",

--- a/RESTFulSense.Tests/Services/Foundations/Properties/PropertyServiceTests.Logic.Retrieve.cs
+++ b/RESTFulSense.Tests/Services/Foundations/Properties/PropertyServiceTests.Logic.Retrieve.cs
@@ -18,10 +18,10 @@ namespace RESTFulSense.Tests.Services.Properties
             // given
             PropertyInfo[] randomPropertyInfos =
                 CreateRandomProperties();
-            
+
             PropertyInfo[] returnedPropertyInfos =
                 randomPropertyInfos;
-            
+
             PropertyInfo[] expectedPropertyInfos =
                 returnedPropertyInfos;
 

--- a/RESTFulSense.Tests/Services/Foundations/Types/TypeServiceTests.Exception.Retrieve.cs
+++ b/RESTFulSense.Tests/Services/Foundations/Types/TypeServiceTests.Exception.Retrieve.cs
@@ -103,7 +103,7 @@ namespace RESTFulSense.Tests.Services.Foundations.Types
                 new FailedTypeServiceException(
                     message: "Failed Type Service Exception occurred, please contact support for assistance.",
                     innerException: someException);
-            
+
             var expectedTypeServiceException =
                 new TypeServiceException(
                     message: "Type service error occurred, contact support.",

--- a/RESTFulSense.Tests/Services/Foundations/Values/ValueServiceTests.Logic.Retrieve.cs
+++ b/RESTFulSense.Tests/Services/Foundations/Values/ValueServiceTests.Logic.Retrieve.cs
@@ -18,7 +18,7 @@ namespace RESTFulSense.Tests.Services.Foundations.Values
             object someObject = CreateSomeObject();
             object someValue = CreateSomeObject();
             object expectedValue = someValue;
-            
+
             PropertyInfo somePropertyInfo =
                 CreateSomePropertyInfo();
 

--- a/RESTFulSense.WebAssembly/Clients/IRESTFulApiClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/IRESTFulApiClient.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,7 +17,7 @@ namespace RESTFulSense.WebAssembly.Clients
         ValueTask<T> GetContentAsync<T>(
             string relativeUrl,
             Func<string, ValueTask<T>> deserializationFunction = null);
-        
+
         ValueTask<T> GetContentAsync<T>(
             string relativeUrl,
             CancellationToken cancellationToken,
@@ -127,11 +128,11 @@ namespace RESTFulSense.WebAssembly.Clients
                 ValueTask<T>> deserializationFunction = null);
 
         ValueTask DeleteContentAsync(string relativeUrl);
-        
+
         ValueTask DeleteContentAsync(
             string relativeUrl,
             CancellationToken cancellationToken);
-        
+
         ValueTask<T> DeleteContentAsync<T>(
             string relativeUrl,
             Func<string, ValueTask<T>> deserializationFunction = null);
@@ -140,5 +141,8 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             CancellationToken cancellationToken,
             Func<string, ValueTask<T>> deserializationFunction = null);
+
+        ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
+            Task<HttpResponseMessage> function);
     }
 }

--- a/RESTFulSense.WebAssembly/Clients/IRESTFulApiFactoryClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/IRESTFulApiFactoryClient.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -131,5 +132,8 @@ namespace RESTFulSense.WebAssembly.Clients
             string relativeUrl,
             CancellationToken cancellationToken,
             Func<string, ValueTask<T>> deserializationFunction = null);
+
+        ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
+            Task<HttpResponseMessage> function);
     }
 }

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.Conversions.NewtonSoft.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.Conversions.NewtonSoft.cs
@@ -7,7 +7,7 @@
 using Newtonsoft.Json;
 
 namespace RESTFulSense.WebAssembly.Clients
-	{
+{
     public partial class RESTFulApiClient
     {
         private static JsonSerializerSettings CreateJsonSerializerSettings(bool ignoreDefaultValues)

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.Conversions.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.Conversions.cs
@@ -56,7 +56,7 @@ namespace RESTFulSense.WebAssembly.Clients
                     mediaType);
 
             return contentString;
-            }
+        }
 
         private static StreamContent ConvertToStreamContent<T>(T content, string mediaType)
             where T : Stream

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiClient.cs
@@ -33,7 +33,7 @@ namespace RESTFulSense.WebAssembly.Clients
         {
             HttpResponseMessage responseMessage =
                 await GetAsync(relativeUrl, cancellationToken);
-            
+
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<T>(responseMessage);
@@ -189,8 +189,8 @@ namespace RESTFulSense.WebAssembly.Clients
             CancellationToken cancellationToken,
             string mediaType = "text/json",
             bool ignoreDefaultValues = false,
-			Func<TContent, ValueTask<string>> serializationFunction = null,
-			Func<string, ValueTask<TResult>> deserializationFunction = null)
+            Func<TContent, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<TResult>> deserializationFunction = null)
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
@@ -217,7 +217,7 @@ namespace RESTFulSense.WebAssembly.Clients
             Func<T, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<T>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
                     content,
                     mediaType,
@@ -243,7 +243,7 @@ namespace RESTFulSense.WebAssembly.Clients
             Func<T, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<T>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
                     content,
                     mediaType,
@@ -297,7 +297,7 @@ namespace RESTFulSense.WebAssembly.Clients
             Func<TContent, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<TResult>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
                     content,
                     mediaType,
@@ -352,7 +352,7 @@ namespace RESTFulSense.WebAssembly.Clients
         {
             HttpResponseMessage responseMessage =
                 await DeleteAsync(relativeUrl);
-            
+
             await ValidationService.ValidateHttpResponseAsync(
                 responseMessage);
         }
@@ -376,7 +376,7 @@ namespace RESTFulSense.WebAssembly.Clients
         {
             HttpResponseMessage responseMessage =
                 await DeleteAsync(relativeUrl);
-            
+
             await ValidationService.ValidateHttpResponseAsync(
                 responseMessage);
 
@@ -413,6 +413,17 @@ namespace RESTFulSense.WebAssembly.Clients
             return deserializationFunction == null
                 ? JsonConvert.DeserializeObject<T>(responseString)
                 : await deserializationFunction(responseString);
+        }
+
+        public async ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
+            Task<HttpResponseMessage> function)
+        {
+            HttpResponseMessage httpResponseMessage =
+                await function;
+
+            await ValidationService.ValidateHttpResponseAsync(httpResponseMessage);
+
+            return httpResponseMessage;
         }
     }
 }

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.Conversions.NewtonSoft.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.Conversions.NewtonSoft.cs
@@ -7,7 +7,7 @@
 using Newtonsoft.Json;
 
 namespace RESTFulSense.WebAssembly.Clients
-	{
+{
     public partial class RESTFulApiFactoryClient
     {
         private static JsonSerializerSettings CreateJsonSerializerSettings(bool ignoreDefaultValues)

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.Conversions.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.Conversions.cs
@@ -56,7 +56,7 @@ namespace RESTFulSense.WebAssembly.Clients
                     mediaType);
 
             return contentString;
-            }
+        }
 
         private static StreamContent ConvertToStreamContent<T>(T content, string mediaType)
             where T : Stream

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.cs
@@ -162,7 +162,7 @@ namespace RESTFulSense.WebAssembly.Clients
             bool ignoreDefaultValues = false,
             Func<T, ValueTask<string>> serializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
                     content,
                     mediaType,
@@ -434,9 +434,9 @@ namespace RESTFulSense.WebAssembly.Clients
                 deserializationFunction);
         }
 
-       private static async ValueTask<T> DeserializeResponseContent<T>(
-            HttpResponseMessage responseMessage,
-            Func<string, ValueTask<T>> deserializationFunction = null)
+        private static async ValueTask<T> DeserializeResponseContent<T>(
+             HttpResponseMessage responseMessage,
+             Func<string, ValueTask<T>> deserializationFunction = null)
         {
             string responseString =
                 await responseMessage.Content.ReadAsStringAsync();
@@ -444,6 +444,17 @@ namespace RESTFulSense.WebAssembly.Clients
             return deserializationFunction == null
                 ? JsonConvert.DeserializeObject<T>(responseString)
                 : await deserializationFunction(responseString);
+        }
+
+        public async ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
+            Task<HttpResponseMessage> function)
+        {
+            HttpResponseMessage httpResponseMessage =
+                await function;
+
+            await ValidationService.ValidateHttpResponseAsync(httpResponseMessage);
+
+            return httpResponseMessage;
         }
     }
 }

--- a/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyApiClientTests.ExecuteHttpCall.cs
+++ b/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyApiClientTests.ExecuteHttpCall.cs
@@ -1,0 +1,48 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RESTFulSense.WebAssenbly.Tests.Acceptance.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace RESTFulSense.WebAssenbly.Tests.Acceptance.Tests
+{
+    public partial class RestfulSenseWebAssemblyApiClientTests
+    {
+        [Fact]
+        private async Task ShouldExecuteHttpCallAsync()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity expectedTEntity = randomTEntity;
+            var httpClient = new HttpClient();
+            httpClient.BaseAddress = new Uri(this.wiremockServer.Urls[0]);
+
+            this.wiremockServer.Given(Request.Create()
+                .WithPath(relativeUrl)
+                .UsingGet())
+                    .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBodyAsJson(expectedTEntity));
+
+            // when
+            HttpResponseMessage httpResponseMessage =
+                await this.restfulWebAssemblyApiClient.ExecuteHttpCallAsync(
+                    httpClient.GetAsync("/tests"));
+
+            TEntity actualTEntityEntity =
+                JsonConvert.DeserializeObject<TEntity>(
+                    await httpResponseMessage.Content.ReadAsStringAsync());
+
+            // then
+            actualTEntityEntity.Should().BeEquivalentTo(expectedTEntity);
+        }
+    }
+}

--- a/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyApiClientTests.PostContent.cs
+++ b/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyApiClientTests.PostContent.cs
@@ -18,7 +18,7 @@ namespace RESTFulSense.WebAssenbly.Tests.Acceptance.Tests
     public partial class RestfulSenseWebAssemblyApiClientTests
     {
         [Fact]
-        private async Task ShouldPostContentWithNoResponseAndDeserializeContentAsync()
+        private void ShouldPostContentWithNoResponseAndDeserializeContent()
         {
             // given
             TEntity randomTEntity = GetRandomTEntity();

--- a/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyFactoryApiClientTests.ExecuteHttpCall.cs
+++ b/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyFactoryApiClientTests.ExecuteHttpCall.cs
@@ -1,0 +1,48 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RESTFulSense.WebAssenbly.Tests.Acceptance.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace RESTFulSense.WebAssenbly.Tests.Acceptance.Tests
+{
+    public partial class RestfulSenseWebAssemblyFactoryApiClientTests
+    {
+        [Fact]
+        private async Task ShouldExecuteHttpCallAsync()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity expectedTEntity = randomTEntity;
+            var httpClient = new HttpClient();
+            httpClient.BaseAddress = new Uri(this.wiremockServer.Urls[0]);
+
+            this.wiremockServer.Given(Request.Create()
+                .WithPath(relativeUrl)
+                .UsingGet())
+                    .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBodyAsJson(expectedTEntity));
+
+            // when
+            HttpResponseMessage httpResponseMessage =
+                await this.webAssemblyApiFactoryClient.ExecuteHttpCallAsync(
+                    httpClient.GetAsync("/tests"));
+
+            TEntity actualTEntityEntity =
+                JsonConvert.DeserializeObject<TEntity>(
+                    await httpResponseMessage.Content.ReadAsStringAsync());
+
+            // then
+            actualTEntityEntity.Should().BeEquivalentTo(expectedTEntity);
+        }
+    }
+}

--- a/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyFactoryApiClientTests.PostContent.cs
+++ b/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyFactoryApiClientTests.PostContent.cs
@@ -18,7 +18,7 @@ namespace RESTFulSense.WebAssenbly.Tests.Acceptance.Tests
     public partial class RestfulSenseWebAssemblyFactoryApiClientTests
     {
         [Fact]
-        private async Task ShouldPostContentWithNoResponseAndDeserializeContentAsync()
+        private void ShouldPostContentWithNoResponseAndDeserializeContent()
         {
             // given
             TEntity randomTEntity = GetRandomTEntity();

--- a/RESTFulSense/Clients/IRESTFulApiClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiClient.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,7 +22,7 @@ namespace RESTFulSense.Clients
         ValueTask<T> GetContentAsync<T>(
             string relativeUrl,
             CancellationToken cancellationToken,
-            Func<string,ValueTask<T>> deserializationFunction = null);
+            Func<string, ValueTask<T>> deserializationFunction = null);
 
         ValueTask<string> GetContentStringAsync(string relativeUrl);
 
@@ -128,7 +129,7 @@ namespace RESTFulSense.Clients
             Func<string, ValueTask<T>> deserializationFunction = null);
 
         ValueTask DeleteContentAsync(string relativeUrl);
-        
+
         ValueTask DeleteContentAsync(
             string relativeUrl,
             CancellationToken cancellationToken);
@@ -141,5 +142,8 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             CancellationToken cancellationToken,
             Func<string, ValueTask<T>> deserializationFunction = null);
+
+        ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
+            Task<HttpResponseMessage> function);
     }
 }

--- a/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,7 +17,7 @@ namespace RESTFulSense.Clients
         ValueTask<T> GetContentAsync<T>(
             string relativeUrl,
             Func<string, ValueTask<T>> deserializationFunction = null);
-        
+
         ValueTask<T> GetContentAsync<T>(
             string relativeUrl,
             CancellationToken cancellationToken,
@@ -74,7 +75,7 @@ namespace RESTFulSense.Clients
             bool ignoreDefaultValues = false,
             Func<TContent, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<TResult>> deserializationFunction = null);
-        
+
         ValueTask<TResult> PostFormAsync<TContent, TResult>(
             string relativeUrl,
             TContent content,
@@ -126,9 +127,9 @@ namespace RESTFulSense.Clients
             Func<string, ValueTask<T>> deserializationFunction = null);
 
         ValueTask DeleteContentAsync(string relativeUrl);
-        
+
         ValueTask DeleteContentAsync(
-            string relativeUrl, 
+            string relativeUrl,
             CancellationToken cancellationToken);
 
         ValueTask<T> DeleteContentAsync<T>(
@@ -139,5 +140,8 @@ namespace RESTFulSense.Clients
             string relativeUrl,
             CancellationToken cancellationToken,
             Func<string, ValueTask<T>> deserializationFunction = null);
+
+        ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
+            Task<HttpResponseMessage> function);
     }
 }

--- a/RESTFulSense/Clients/RESTFulApiClient.Conversions.cs
+++ b/RESTFulSense/Clients/RESTFulApiClient.Conversions.cs
@@ -30,7 +30,7 @@ namespace RESTFulSense.Clients
                     content, mediaType, ignoreDefaultValues, serializationFunction),
 
                 "text/plain" => ConvertToStringContent(content, mediaType),
-                
+
                 "application/octet-stream" => ConvertToStreamContent(content as Stream, mediaType),
                 _ => ConvertToStringContent(content, mediaType)
             };
@@ -40,7 +40,7 @@ namespace RESTFulSense.Clients
         {
             return new StringContent(
                 content: content.ToString(),
-                encoding: Encoding.UTF8, 
+                encoding: Encoding.UTF8,
                 mediaType);
         }
 

--- a/RESTFulSense/Clients/RESTFulApiClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiClient.cs
@@ -22,7 +22,7 @@ namespace RESTFulSense.Clients
     public partial class RESTFulApiClient : HttpClient, IRESTFulApiClient
     {
         private IFormCoordinationService formCoordinationService;
-        
+
         public RESTFulApiClient()
         {
             IServiceProvider serviceProvider = RegisterFormServices();
@@ -47,7 +47,7 @@ namespace RESTFulSense.Clients
             CancellationToken cancellationToken,
             Func<string, ValueTask<T>> deserializationFunction = null)
         {
-            HttpResponseMessage responseMessage = 
+            HttpResponseMessage responseMessage =
                 await GetAsync(relativeUrl, cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
@@ -83,9 +83,9 @@ namespace RESTFulSense.Clients
             Func<T, ValueTask<string>> serializationFunction = null)
         {
             HttpContent contentString = await ConvertToHttpContent(
-                content, 
-                mediaType, 
-                ignoreDefaultValues, 
+                content,
+                mediaType,
+                ignoreDefaultValues,
                 serializationFunction);
 
             HttpResponseMessage responseMessage =
@@ -103,9 +103,9 @@ namespace RESTFulSense.Clients
             Func<T, ValueTask<string>> serializationFunction = null)
         {
             HttpContent contentString = await ConvertToHttpContent(
-                content, 
-                mediaType, 
-                ignoreDefaultValues, 
+                content,
+                mediaType,
+                ignoreDefaultValues,
                 serializationFunction);
 
             HttpResponseMessage responseMessage =
@@ -160,14 +160,14 @@ namespace RESTFulSense.Clients
             bool ignoreDefaultValues = false,
             Func<T, ValueTask<string>> serializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
-            HttpResponseMessage responseMessage = 
+            HttpResponseMessage responseMessage =
                 await PostAsync(relativeUrl, contentString);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
@@ -183,16 +183,16 @@ namespace RESTFulSense.Clients
             Func<TContent, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<TResult>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
-            HttpResponseMessage responseMessage = 
+            HttpResponseMessage responseMessage =
                 await PostAsync(relativeUrl, contentString);
-           
+
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<TResult>(
@@ -208,11 +208,11 @@ namespace RESTFulSense.Clients
             Func<TContent, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<TResult>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
@@ -270,21 +270,21 @@ namespace RESTFulSense.Clients
             Func<T, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<T>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
-            HttpResponseMessage responseMessage = 
+            HttpResponseMessage responseMessage =
                 await PutAsync(relativeUrl, contentString);
 
             await ValidationService.ValidateHttpResponseAsync
                 (responseMessage);
 
             return await DeserializeResponseContent<T>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -297,14 +297,14 @@ namespace RESTFulSense.Clients
             Func<T, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<T>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
-            HttpResponseMessage responseMessage = 
+            HttpResponseMessage responseMessage =
                 await PutAsync(relativeUrl, contentString, cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
@@ -321,16 +321,16 @@ namespace RESTFulSense.Clients
             Func<TContent, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<TResult>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
-            HttpResponseMessage responseMessage = 
+            HttpResponseMessage responseMessage =
                 await PutAsync(relativeUrl, contentString);
-            
+
             await ValidationService.ValidateHttpResponseAsync(
                 responseMessage);
 
@@ -347,11 +347,11 @@ namespace RESTFulSense.Clients
             Func<TContent, ValueTask<string>> serializationFunction = null,
             Func<string, ValueTask<TResult>> deserializationFunction = null)
         {
-            HttpContent contentString = 
+            HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
@@ -407,7 +407,7 @@ namespace RESTFulSense.Clients
         }
 
         public async ValueTask<T> DeleteContentAsync<T>(
-            string relativeUrl, 
+            string relativeUrl,
             Func<string, ValueTask<T>> deserializationFunction = null)
         {
             HttpResponseMessage responseMessage = await DeleteAsync(relativeUrl);
@@ -441,6 +441,17 @@ namespace RESTFulSense.Clients
             return deserializationFunction == null
                 ? JsonConvert.DeserializeObject<T>(responseString)
                 : await deserializationFunction(responseString);
+        }
+
+        public async ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
+            Task<HttpResponseMessage> function)
+        {
+            HttpResponseMessage httpResponseMessage =
+                await function;
+
+            await ValidationService.ValidateHttpResponseAsync(httpResponseMessage);
+
+            return httpResponseMessage;
         }
     }
 }

--- a/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
@@ -88,9 +88,9 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
@@ -109,15 +109,15 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
                 await this.httpClient.PostAsync(
-                    relativeUrl, 
-                    contentString, 
+                    relativeUrl,
+                    contentString,
                     cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
@@ -169,15 +169,15 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
                 await this.httpClient.PostAsync(
-                    relativeUrl, 
-                    contentString, 
+                    relativeUrl,
+                    contentString,
                     cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
@@ -195,9 +195,9 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
@@ -220,21 +220,21 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PostAsync(
-                   relativeUrl, 
-                   contentString, 
+                   relativeUrl,
+                   contentString,
                    cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<TResult>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -248,9 +248,9 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
@@ -259,7 +259,7 @@ namespace RESTFulSense.Clients
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<T>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -277,14 +277,14 @@ namespace RESTFulSense.Clients
 
                 HttpResponseMessage responseMessage =
                    await this.httpClient.PostAsync(
-                       relativeUrl, 
-                       multipartFormDataContent, 
+                       relativeUrl,
+                       multipartFormDataContent,
                        cancellationToken);
 
                 await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
                 return await DeserializeResponseContent<TResult>(
-                    responseMessage, 
+                    responseMessage,
                     deserializationFunction);
             }
             catch (FormCoordinationValidationException formCoordinationValidationException)
@@ -315,21 +315,21 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(
-                   relativeUrl, 
-                   contentString, 
+                   relativeUrl,
+                   contentString,
                    cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<T>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -343,9 +343,9 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
@@ -354,7 +354,7 @@ namespace RESTFulSense.Clients
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<TResult>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -369,21 +369,21 @@ namespace RESTFulSense.Clients
         {
             HttpContent contentString =
                 await ConvertToHttpContent(
-                    content, 
-                    mediaType, 
-                    ignoreDefaultValues, 
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
                     serializationFunction);
 
             HttpResponseMessage responseMessage =
                await this.httpClient.PutAsync(
-                   relativeUrl, 
-                   contentString, 
+                   relativeUrl,
+                   contentString,
                    cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<TResult>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -397,7 +397,7 @@ namespace RESTFulSense.Clients
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<T>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -408,15 +408,15 @@ namespace RESTFulSense.Clients
         {
             HttpResponseMessage responseMessage =
                 await this.httpClient.PutAsync(
-                    relativeUrl, 
-                    content: default, 
+                    relativeUrl,
+                    content: default,
                     cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(
                 responseMessage);
 
             return await DeserializeResponseContent<T>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -429,12 +429,12 @@ namespace RESTFulSense.Clients
         }
 
         public async ValueTask DeleteContentAsync(
-            string relativeUrl, 
+            string relativeUrl,
             CancellationToken cancellationToken)
         {
             HttpResponseMessage responseMessage =
                 await this.httpClient.DeleteAsync(
-                    relativeUrl, 
+                    relativeUrl,
                     cancellationToken);
 
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
@@ -451,7 +451,7 @@ namespace RESTFulSense.Clients
                 responseMessage);
 
             return await DeserializeResponseContent<T>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -466,7 +466,7 @@ namespace RESTFulSense.Clients
             await ValidationService.ValidateHttpResponseAsync(responseMessage);
 
             return await DeserializeResponseContent<T>(
-                responseMessage, 
+                responseMessage,
                 deserializationFunction);
         }
 
@@ -474,12 +474,23 @@ namespace RESTFulSense.Clients
             HttpResponseMessage responseMessage,
             Func<string, ValueTask<T>> deserializationFunction = null)
         {
-            string responseString = 
+            string responseString =
                 await responseMessage.Content.ReadAsStringAsync();
 
             return deserializationFunction == null
                 ? JsonConvert.DeserializeObject<T>(responseString)
                 : await deserializationFunction(responseString);
+        }
+
+        public async ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
+            Task<HttpResponseMessage> function)
+        {
+            HttpResponseMessage httpResponseMessage =
+                await function;
+
+            await ValidationService.ValidateHttpResponseAsync(httpResponseMessage);
+
+            return httpResponseMessage;
         }
     }
 }

--- a/RESTFulSense/Models/Client/Exceptions/RESTFulApiClientDependencyException.cs
+++ b/RESTFulSense/Models/Client/Exceptions/RESTFulApiClientDependencyException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Client.Exceptions
                 message: "Form coordination dependency error occurred, fix the errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public RESTFulApiClientDependencyException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Client/Exceptions/RESTFulApiClientServiceException.cs
+++ b/RESTFulSense/Models/Client/Exceptions/RESTFulApiClientServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Client.Exceptions
                 message: "Api Client error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public RESTFulApiClientServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Client/Exceptions/RESTFulApiClientValidationException.cs
+++ b/RESTFulSense/Models/Client/Exceptions/RESTFulApiClientValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Client.Exceptions
                 message: "Api Client validation errors occurred, please try again.",
                 innerException: innerException)
         { }
-        
+
         public RESTFulApiClientValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Coordinations/Forms/Exceptions/FailedFormCoordinationServiceException.cs
+++ b/RESTFulSense/Models/Coordinations/Forms/Exceptions/FailedFormCoordinationServiceException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Coordinations.Forms.Exceptions
                 message: "Form coordination service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public FailedFormCoordinationServiceException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Coordinations/Forms/Exceptions/FormCoordinationDependencyException.cs
+++ b/RESTFulSense/Models/Coordinations/Forms/Exceptions/FormCoordinationDependencyException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Coordinations.Forms.Exceptions
                 message: "Form coordination dependency error occurred, fix the errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public FormCoordinationDependencyException(string message, Xeption innerException)
          : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Coordinations/Forms/Exceptions/FormCoordinationDependencyValidationException.cs
+++ b/RESTFulSense/Models/Coordinations/Forms/Exceptions/FormCoordinationDependencyValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Coordinations.Forms.Exceptions
                 message: "Form coordination dependency validation error occurred, fix the errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public FormCoordinationDependencyValidationException(string message, Xeption innerException)
          : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Coordinations/Forms/Exceptions/FormCoordinationServiceException.cs
+++ b/RESTFulSense/Models/Coordinations/Forms/Exceptions/FormCoordinationServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Coordinations.Forms.Exceptions
                 message: "Form coordination service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public FormCoordinationServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Coordinations/Forms/Exceptions/FormCoordinationValidationException.cs
+++ b/RESTFulSense/Models/Coordinations/Forms/Exceptions/FormCoordinationValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Coordinations.Forms.Exceptions
                 message: "Form coordination validation errors occurred, please try again.",
                 innerException: innerException)
         { }
-        
+
         public FormCoordinationValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Coordinations/Forms/Exceptions/NullObjectException.cs
+++ b/RESTFulSense/Models/Coordinations/Forms/Exceptions/NullObjectException.cs
@@ -11,7 +11,7 @@ namespace RESTFulSense.Models.Coordinations.Forms.Exceptions
         public NullObjectException()
             : base(message: "Object is null.")
         { }
-        
+
         public NullObjectException(string message)
             : base(message)
         { }

--- a/RESTFulSense/Models/Foundations/Attributes/Exceptions/AttributeDependencyException.cs
+++ b/RESTFulSense/Models/Foundations/Attributes/Exceptions/AttributeDependencyException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Attributes.Exceptions
                 message: "Attribute dependency error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public AttributeDependencyException(string message, Xeption innerException) :
             base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Attributes/Exceptions/AttributeDependencyValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Attributes/Exceptions/AttributeDependencyValidationException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Attributes.Exceptions
                 message: "Attribute dependency validation error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public AttributeDependencyValidationException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Attributes/Exceptions/AttributeServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Attributes/Exceptions/AttributeServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Attributes.Exceptions
                 message: "Attribute service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public AttributeServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Attributes/Exceptions/AttributeValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Attributes/Exceptions/AttributeValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Attributes.Exceptions
                 message: "Attribute validation error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public AttributeValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Attributes/Exceptions/FailedAttributeServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Attributes/Exceptions/FailedAttributeServiceException.cs
@@ -14,9 +14,9 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
                 message: "Failed Attribute Service Exception occurred, please contact support for assistance.",
                 innerException: innerException)
         { }
-        
+
         public FailedAttributeServiceException(string message, Exception innerException)
-        : base(message,innerException)
+        : base(message, innerException)
         { }
     }
 }

--- a/RESTFulSense/Models/Foundations/Attributes/Exceptions/NullPropertyInfoException.cs
+++ b/RESTFulSense/Models/Foundations/Attributes/Exceptions/NullPropertyInfoException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Attributes.Exceptions
                 message: "PropertyInfo is null, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public NullPropertyInfoException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Forms/Exceptions/FailedFormServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Forms/Exceptions/FailedFormServiceException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Forms.Exceptions
                 message: "Failed Form Service Exception occurred, please contact support for assistance.",
                 innerException: innerException)
         { }
-        
+
         public FailedFormServiceException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Forms/Exceptions/FormDependencyException.cs
+++ b/RESTFulSense/Models/Foundations/Forms/Exceptions/FormDependencyException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Forms.Exceptions
                 message: "Form dependency error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public FormDependencyException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Forms/Exceptions/FormDependencyValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Forms/Exceptions/FormDependencyValidationException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Forms.Exceptions
                 message: "Form dependency validation error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public FormDependencyValidationException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Forms/Exceptions/FormServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Forms/Exceptions/FormServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Forms.Exceptions
                 message: "Form service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public FormServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Forms/Exceptions/FormValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Forms/Exceptions/FormValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Forms.Exceptions
                 message: "Form validation error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public FormValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Forms/Exceptions/InvalidFormArgumentException.cs
+++ b/RESTFulSense/Models/Foundations/Forms/Exceptions/InvalidFormArgumentException.cs
@@ -11,7 +11,7 @@ namespace RESTFulSense.Models.Foundations.Forms.Exceptions
         public InvalidFormArgumentException()
             : base(message: "Invalid form arguments. Please fix the errors and try again.")
         { }
-        
+
         public InvalidFormArgumentException(string message)
             : base(message)
         { }

--- a/RESTFulSense/Models/Foundations/Properties/Exceptions/FailedPropertyDependencyException.cs
+++ b/RESTFulSense/Models/Foundations/Properties/Exceptions/FailedPropertyDependencyException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
                 message: "Property dependency error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public FailedPropertyDependencyException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Properties/Exceptions/FailedPropertyDependencyValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Properties/Exceptions/FailedPropertyDependencyValidationException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
                 message: "Failed property dependency validation error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public FailedPropertyDependencyValidationException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Properties/Exceptions/FailedPropertyServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Properties/Exceptions/FailedPropertyServiceException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
                 message: "Failed Property Service Exception occurred, please contact support for assistance.",
                 innerException: innerException)
         { }
-        
+
         public FailedPropertyServiceException(string message, Exception innerException)
         : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Properties/Exceptions/NullTypeException.cs
+++ b/RESTFulSense/Models/Foundations/Properties/Exceptions/NullTypeException.cs
@@ -11,7 +11,7 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
         public NullTypeException()
             : base(message: "Type is null.")
         { }
-        
+
         public NullTypeException(string message)
             : base(message)
         { }

--- a/RESTFulSense/Models/Foundations/Properties/Exceptions/PropertyDependencyException.cs
+++ b/RESTFulSense/Models/Foundations/Properties/Exceptions/PropertyDependencyException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
                 message: "Property dependency error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public PropertyDependencyException(string message, Xeption innerException) :
             base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Properties/Exceptions/PropertyDependencyValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Properties/Exceptions/PropertyDependencyValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
                 message: "Property dependency validation occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public PropertyDependencyValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Properties/Exceptions/PropertyServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Properties/Exceptions/PropertyServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
                 message: "Property service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public PropertyServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Properties/Exceptions/PropertyValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Properties/Exceptions/PropertyValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Properties.Exceptions
                 message: "Property validation errors occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public PropertyValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Types/Exceptions/FailedTypeDependencyException.cs
+++ b/RESTFulSense/Models/Foundations/Types/Exceptions/FailedTypeDependencyException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Types.Exceptions
                 message: "Type dependency error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public FailedTypeDependencyException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Types/Exceptions/FailedTypeDependencyValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Types/Exceptions/FailedTypeDependencyValidationException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Types.Exceptions
                 message: "Failed type dependency validation error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public FailedTypeDependencyValidationException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Types/Exceptions/FailedTypeServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Types/Exceptions/FailedTypeServiceException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Types.Exceptions
                 message: "Failed Type Service Exception occurred, please contact support for assistance.",
                 innerException: innerException)
         { }
-        
+
         public FailedTypeServiceException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Types/Exceptions/NullObjectException.cs
+++ b/RESTFulSense/Models/Foundations/Types/Exceptions/NullObjectException.cs
@@ -11,7 +11,7 @@ namespace RESTFulSense.Models.Foundations.Types.Exceptions
         public NullObjectException()
             : base(message: "Object is null.")
         { }
-        
+
         public NullObjectException(string message)
             : base(message)
         { }

--- a/RESTFulSense/Models/Foundations/Types/Exceptions/TypeDependencyException.cs
+++ b/RESTFulSense/Models/Foundations/Types/Exceptions/TypeDependencyException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Types.Exceptions
                 message: "Type dependency error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public TypeDependencyException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Types/Exceptions/TypeDependencyValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Types/Exceptions/TypeDependencyValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Types.Exceptions
                 message: "Type dependency validation occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public TypeDependencyValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Types/Exceptions/TypeServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Types/Exceptions/TypeServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Types.Exceptions
                 message: "Type service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public TypeServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Types/Exceptions/TypeValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Types/Exceptions/TypeValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Types.Exceptions
                 message: "Type validation errors occurred, fix errors and try again.",
                 innerException)
         { }
-        
+
         public TypeValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Values/Exceptions/FailedValueServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Values/Exceptions/FailedValueServiceException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Foundations.Values.Exceptions
                 message: "Failed Value Service Exception occurred, please contact support for assistance.",
                 innerException: innerException)
         { }
-        
+
         public FailedValueServiceException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Values/Exceptions/ValueDependencyException.cs
+++ b/RESTFulSense/Models/Foundations/Values/Exceptions/ValueDependencyException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Values.Exceptions
                 message: "Value dependency error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public ValueDependencyException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Values/Exceptions/ValueDependencyValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Values/Exceptions/ValueDependencyValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Values.Exceptions
                 message: "Value dependency validation occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public ValueDependencyValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Values/Exceptions/ValueServiceException.cs
+++ b/RESTFulSense/Models/Foundations/Values/Exceptions/ValueServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Values.Exceptions
                 message: "Value service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public ValueServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Foundations/Values/Exceptions/ValueValidationException.cs
+++ b/RESTFulSense/Models/Foundations/Values/Exceptions/ValueValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Foundations.Values.Exceptions
                 message: "Value validation errors occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public ValueValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FailedFormOrchestrationServiceException.cs
+++ b/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FailedFormOrchestrationServiceException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Orchestrations.Forms.Exceptions
                 message: "Failed form orchestration service occurred, please contact support",
                 innerException: innerException)
         { }
-        
+
         public FailedFormOrchestrationServiceException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FormOrchestrationDependencyException.cs
+++ b/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FormOrchestrationDependencyException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Orchestrations.Forms.Exceptions
                 message: "Form orchestration dependency error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public FormOrchestrationDependencyException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FormOrchestrationDependencyValidationException.cs
+++ b/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FormOrchestrationDependencyValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Orchestrations.Forms.Exceptions
                 message: "Form orchestration dependency validation error occurred, fix the errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public FormOrchestrationDependencyValidationException(string message, Xeption innerException)
          : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FormOrchestrationServiceException.cs
+++ b/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FormOrchestrationServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Orchestrations.Forms.Exceptions
                 message: "Form orchestration service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public FormOrchestrationServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FormOrchestrationValidationException.cs
+++ b/RESTFulSense/Models/Orchestrations/Forms/Exceptions/FormOrchestrationValidationException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Orchestrations.Forms.Exceptions
                 message: "Form orchestration validation errors occurred, please try again.",
                 innerException: innerException)
         { }
-        
+
         public FormOrchestrationValidationException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Forms/Exceptions/NullFormModelException.cs
+++ b/RESTFulSense/Models/Orchestrations/Forms/Exceptions/NullFormModelException.cs
@@ -12,7 +12,7 @@ namespace RESTFulSense.Models.Orchestrations.Forms.Exceptions
             : base(
                 message: "Form model is null. Please correct the errors and try again.")
         { }
-        
+
         public NullFormModelException(string message)
             : base(message)
         { }

--- a/RESTFulSense/Models/Orchestrations/Properties/Exceptions/FailedPropertyOrchestrationException.cs
+++ b/RESTFulSense/Models/Orchestrations/Properties/Exceptions/FailedPropertyOrchestrationException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Orchestrations.Properties.Exceptions
                   message: "Failed property orchestration service exception occurred, please contact support.",
                   innerException: innerException)
         { }
-        
+
         public FailedPropertyOrchestrationException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Properties/Exceptions/NullObjectException.cs
+++ b/RESTFulSense/Models/Orchestrations/Properties/Exceptions/NullObjectException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Orchestrations.Properties.Exceptions
                 message: "Object is null, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public NullObjectException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Properties/Exceptions/NullPropertyModelException.cs
+++ b/RESTFulSense/Models/Orchestrations/Properties/Exceptions/NullPropertyModelException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Orchestrations.Properties.Exceptions
                 message: "PropertyModel is null, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public NullPropertyModelException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Properties/Exceptions/PropertyOrchestrationDependencyException.cs
+++ b/RESTFulSense/Models/Orchestrations/Properties/Exceptions/PropertyOrchestrationDependencyException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Orchestrations.Properties.Exceptions
                 message: "Property orchestration dependency error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public PropertyOrchestrationDependencyException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Properties/Exceptions/PropertyOrchestrationDependencyValidationException.cs
+++ b/RESTFulSense/Models/Orchestrations/Properties/Exceptions/PropertyOrchestrationDependencyValidationException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Orchestrations.Properties.Exceptions
                 message: "Property orchestration dependency validation error occurred, fix errors and try again.",
                 innerException: innerException)
         { }
-        
+
         public PropertyOrchestrationDependencyValidationException(string message, Exception innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Properties/Exceptions/PropertyOrchestrationServiceException.cs
+++ b/RESTFulSense/Models/Orchestrations/Properties/Exceptions/PropertyOrchestrationServiceException.cs
@@ -13,7 +13,7 @@ namespace RESTFulSense.Models.Orchestrations.Properties.Exceptions
                 message: "Property orchestration service error occurred, contact support.",
                 innerException: innerException)
         { }
-        
+
         public PropertyOrchestrationServiceException(string message, Xeption innerException)
             : base(message, innerException)
         { }

--- a/RESTFulSense/Models/Orchestrations/Properties/Exceptions/PropertyOrchestrationValidationException.cs
+++ b/RESTFulSense/Models/Orchestrations/Properties/Exceptions/PropertyOrchestrationValidationException.cs
@@ -14,7 +14,7 @@ namespace RESTFulSense.Models.Orchestrations.Properties.Exceptions
                   message: "Property validation error occurred, fix errors and try again.",
                   innerException: innerException)
         { }
-        
+
         public PropertyOrchestrationValidationException(string message, Exception innerException)
             : base(message, innerException)
         { }


### PR DESCRIPTION
There are several cases where RESTFulSense doesn't yet implement a functionality that `HttpClient` already offers.
Here are some examples:
- PATCH
- FORM
- HEAD
- OPTIONS

amongst many others.

This implementation enables any http call to be passed onto a `ExecuteCallAsync` function that validates the `HttpResponseMessage` and throws a proper exception if found.

Here's an example:

```csharp
var httpClient = new HttpClient();
httpClient.BaseAddress = 
httpClient.BaseAddress = new Uri("hassanhabib.com");

HttpMessageResponse =
    await this.restfulApiClient.ExecuteHttpCallAsync(
        httpClient.GetAsync("/tests"));
```

The above `ExecuteHttpCallAsync` will take care of handling any `HttpResponseException` and convert the response if erroneous into a meaningful exception like `HttpBadRequestException` and so on.
