### PR TITLE
CONTROLLERS: Support Custom Http Methods (Client & Server)

### DIFF
--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulApiClientTests.SendHttpRequest.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulApiClientTests.SendHttpRequest.cs
@@ -1,0 +1,89 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RESTFulSense.Tests.Acceptance.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace RESTFulSense.Tests.Acceptance.Tests
+{
+    public partial class RestfulApiClientTests
+    {
+
+        [Fact]
+        private void ShouldSendContentWithNoResponseAndDeserializeContent()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity inputTEntity = randomTEntity;
+            TEntity expectedTEntity = inputTEntity;
+            string mediaType = "application/json";
+            bool ignoreDefaultValues = false;
+            string randomHttpMethodName = GetRandomHttpMethodName();
+
+            this.wiremockServer.Given(Request.Create()
+                .WithPath(relativeUrl)
+                .UsingMethod(randomHttpMethodName))
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200));
+
+            // when
+            Action actualResponseResult = async () =>
+                await this.restfulApiClient.SendHttpRequestAsync<TEntity>(
+                    method: randomHttpMethodName,
+                    relativeUrl: relativeUrl,
+                    content: inputTEntity,
+                    mediaType: mediaType,
+                    ignoreDefaultValues: ignoreDefaultValues,
+                    serializationFunction: SerializationContentFunction);
+
+            // then
+            actualResponseResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        private async Task ShouldSendContentWithTContentReturnsTResultAsync()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity inputTEntity = randomTEntity;
+            TEntity expectedTEntity = inputTEntity;
+            string mediaType = "text/json";
+            bool ignoreDefaultValues = false;
+            string randomHttpMethodName = GetRandomHttpMethodName();
+
+            string expectedBody =
+               JsonConvert.SerializeObject(randomTEntity);
+
+            this.wiremockServer.Given(
+                Request.Create()
+                .WithPath(relativeUrl)
+                .UsingMethod(randomHttpMethodName))
+                    .RespondWith(
+                        Response.Create()
+                            .WithStatusCode(200)
+                            .WithHeader("Content-Type", mediaType)
+                            .WithBody(expectedBody));
+
+            // when
+            TEntity actualTEntity =
+                await this.restfulApiClient.SendHttpRequestAsync<TEntity, TEntity>(
+                    method: randomHttpMethodName,
+                    relativeUrl: relativeUrl,
+                    content: inputTEntity,
+                    mediaType: mediaType,
+                    ignoreDefaultValues: ignoreDefaultValues,
+                    serializationFunction: SerializationContentFunction,
+                    deserializationFunction: DeserializationContentFunction);
+
+            // then
+            actualTEntity.Should().BeEquivalentTo(expectedTEntity);
+        }
+    }
+}

--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulApiClientTests.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulApiClientTests.cs
@@ -65,6 +65,9 @@ namespace RESTFulSense.Tests.Acceptance.Tests
         private static TEntity GetRandomTEntity() =>
             CreateTEntityFiller(GetTestDateTimeOffset()).Create();
 
+        private static string GetRandomHttpMethodName() =>
+            new MnemonicString().GetValue();
+
         private static DateTimeOffset GetTestDateTimeOffset() =>
             new DateTimeOffset(DateTime.Now);
 

--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.SendHttpRequest.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.SendHttpRequest.cs
@@ -1,0 +1,88 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RESTFulSense.Tests.Acceptance.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace RESTFulSense.Tests.Acceptance.Tests
+{
+    public partial class RestfulSenseApiFactoryTests
+    {
+        [Fact]
+        private void ShouldSendContentWithNoResponseAndDeserializeContent()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity inputTEntity = randomTEntity;
+            TEntity expectedTEntity = inputTEntity;
+            string mediaType = "application/json";
+            bool ignoreDefaultValues = false;
+            string randomHttpMethodName = GetRandomHttpMethodName();
+
+            this.wiremockServer.Given(Request.Create()
+                .WithPath(relativeUrl)
+                .UsingMethod(randomHttpMethodName))
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200));
+
+            // when
+            Action actualResponseResult = async () =>
+                await this.factoryClient.SendHttpRequestAsync<TEntity>(
+                    method: randomHttpMethodName,
+                    relativeUrl: relativeUrl,
+                    content: inputTEntity,
+                    mediaType: mediaType,
+                    ignoreDefaultValues: ignoreDefaultValues,
+                    serializationFunction: SerializationContentFunction);
+
+            // then
+            actualResponseResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        private async Task ShouldSendContentWithTContentReturnsTResultAsync()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity inputTEntity = randomTEntity;
+            TEntity expectedTEntity = inputTEntity;
+            string mediaType = "text/json";
+            bool ignoreDefaultValues = false;
+            string randomHttpMethodName = GetRandomHttpMethodName();
+
+            string expectedBody =
+               JsonConvert.SerializeObject(randomTEntity);
+
+            this.wiremockServer.Given(
+                Request.Create()
+                .WithPath(relativeUrl)
+                .UsingMethod(randomHttpMethodName))
+                    .RespondWith(
+                        Response.Create()
+                            .WithStatusCode(200)
+                            .WithHeader("Content-Type", mediaType)
+                            .WithBody(expectedBody));
+
+            // when
+            TEntity actualTEntity =
+                await this.factoryClient.SendHttpRequestAsync<TEntity, TEntity>(
+                    method: randomHttpMethodName,
+                    relativeUrl: relativeUrl,
+                    content: inputTEntity,
+                    mediaType: mediaType,
+                    ignoreDefaultValues: ignoreDefaultValues,
+                    serializationFunction: SerializationContentFunction,
+                    deserializationFunction: ContentDeserializationFunction);
+
+            // then
+            actualTEntity.Should().BeEquivalentTo(expectedTEntity);
+        }
+    }
+}

--- a/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.cs
+++ b/RESTFulSense.Tests.Acceptance/Tests/RestfulSenseApiFactoryTests.cs
@@ -68,6 +68,9 @@ namespace RESTFulSense.Tests.Acceptance.Tests
         private static TEntity GetRandomTEntity() =>
             CreateTEntityFiller(GetTestDateTimeOffset()).Create();
 
+        private static string GetRandomHttpMethodName() =>
+            new MnemonicString().GetValue();
+
         private static DateTimeOffset GetTestDateTimeOffset() =>
             new DateTimeOffset(DateTime.Now);
 

--- a/RESTFulSense.WebAssembly/Clients/IRESTFulApiClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/IRESTFulApiClient.cs
@@ -144,5 +144,29 @@ namespace RESTFulSense.WebAssembly.Clients
 
         ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
             Task<HttpResponseMessage> function);
+
+        ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            CancellationToken cancellationToken,
+            Func<string, ValueTask<T>> deserailizationFunction = null);
+
+        ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<T, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<T>> deserializationFunction = null);
+
+        ValueTask<TResult> SendHttpRequestAsync<TContent, TResult>(
+            string method,
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<TContent, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<TResult>> deserializationFunction = null);
     }
 }

--- a/RESTFulSense.WebAssembly/Clients/IRESTFulApiFactoryClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/IRESTFulApiFactoryClient.cs
@@ -135,5 +135,29 @@ namespace RESTFulSense.WebAssembly.Clients
 
         ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
             Task<HttpResponseMessage> function);
+
+        ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            CancellationToken cancellationToken,
+            Func<string, ValueTask<T>> deserailizationFunction = null);
+
+        ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<T, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<T>> deserializationFunction = null);
+
+        ValueTask<TResult> SendHttpRequestAsync<TContent, TResult>(
+            string method,
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<TContent, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<TResult>> deserializationFunction = null);
     }
 }

--- a/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense.WebAssembly/Clients/RESTFulApiFactoryClient.cs
@@ -456,5 +456,90 @@ namespace RESTFulSense.WebAssembly.Clients
 
             return httpResponseMessage;
         }
+
+        public async ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            CancellationToken cancellationToken,
+            Func<string, ValueTask<T>> deserializationFunction = null)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await this.httpClient.SendAsync(
+                    request: new HttpRequestMessage(httpMethod, relativeUrl),
+                    cancellationToken: cancellationToken);
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent<T>(
+                responseMessage, deserializationFunction);
+        }
+
+        public async ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<T, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<T>> deserializationFunction = null)
+        {
+            HttpContent contentString =
+                await ConvertToHttpContent(
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
+                    serializationFunction);
+
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await this.httpClient.SendAsync(
+                    request: new HttpRequestMessage
+                    {
+                        Method = httpMethod,
+                        RequestUri = new Uri(relativeUrl),
+                        Content = contentString
+                    });
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent<T>(
+                responseMessage,
+                deserializationFunction);
+        }
+
+        public async ValueTask<TResult> SendHttpRequestAsync<TContent, TResult>(
+            string method,
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<TContent, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<TResult>> deserializationFunction = null)
+        {
+            HttpContent contentString =
+                await ConvertToHttpContent(
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
+                    serializationFunction);
+
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await this.httpClient.SendAsync(
+                    request: new HttpRequestMessage(httpMethod, relativeUrl)
+                    {
+                        Content = contentString
+                    });
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent(
+                responseMessage,
+                deserializationFunction);
+        }
     }
 }

--- a/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyApiClientTests.SendHttpRequest.cs
+++ b/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyApiClientTests.SendHttpRequest.cs
@@ -1,0 +1,88 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RESTFulSense.WebAssenbly.Tests.Acceptance.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace RESTFulSense.WebAssenbly.Tests.Acceptance.Tests
+{
+    public partial class RestfulSenseWebAssemblyApiClientTests
+    {
+        [Fact]
+        private void ShouldSendContentWithNoResponseAndDeserializeContent()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity inputTEntity = randomTEntity;
+            TEntity expectedTEntity = inputTEntity;
+            string mediaType = "application/json";
+            bool ignoreDefaultValues = false;
+            string randomHttpMethodName = GetRandomHttpMethodName();
+
+            this.wiremockServer.Given(Request.Create()
+                .WithPath(relativeUrl)
+                .UsingMethod(randomHttpMethodName))
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200));
+
+            // when
+            Action actualResponseResult = async () =>
+                await this.restfulWebAssemblyApiClient.SendHttpRequestAsync<TEntity>(
+                    method: randomHttpMethodName,
+                    relativeUrl: relativeUrl,
+                    content: inputTEntity,
+                    mediaType: mediaType,
+                    ignoreDefaultValues: ignoreDefaultValues,
+                    serializationFunction: SerializationContentFunction);
+
+            // then
+            actualResponseResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        private async Task ShouldSendContentWithTContentReturnsTResultAsync()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity inputTEntity = randomTEntity;
+            TEntity expectedTEntity = inputTEntity;
+            string mediaType = "text/json";
+            bool ignoreDefaultValues = false;
+            string randomHttpMethodName = GetRandomHttpMethodName();
+
+            string expectedBody =
+               JsonConvert.SerializeObject(randomTEntity);
+
+            this.wiremockServer.Given(
+                Request.Create()
+                .WithPath(relativeUrl)
+                .UsingMethod(randomHttpMethodName))
+                    .RespondWith(
+                        Response.Create()
+                            .WithStatusCode(200)
+                            .WithHeader("Content-Type", mediaType)
+                            .WithBody(expectedBody));
+
+            // when
+            TEntity actualTEntity =
+                await this.restfulWebAssemblyApiClient.SendHttpRequestAsync<TEntity, TEntity>(
+                    method: randomHttpMethodName,
+                    relativeUrl: relativeUrl,
+                    content: inputTEntity,
+                    mediaType: mediaType,
+                    ignoreDefaultValues: ignoreDefaultValues,
+                    serializationFunction: SerializationContentFunction,
+                    deserializationFunction: DeserializationContentFunction);
+
+            // then
+            actualTEntity.Should().BeEquivalentTo(expectedTEntity);
+        }
+    }
+}

--- a/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyApiClientTests.cs
+++ b/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyApiClientTests.cs
@@ -65,6 +65,9 @@ namespace RESTFulSense.WebAssenbly.Tests.Acceptance.Tests
         private static TEntity GetRandomTEntity() =>
             CreateTEntityFiller(GetTestDateTimeOffset()).Create();
 
+        private static string GetRandomHttpMethodName() =>
+            new MnemonicString().GetValue();
+
         private static DateTimeOffset GetTestDateTimeOffset() =>
             new DateTimeOffset(DateTime.Now);
 

--- a/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyFactoryApiClientTests.SendHttpRequest.cs
+++ b/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyFactoryApiClientTests.SendHttpRequest.cs
@@ -1,0 +1,88 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RESTFulSense.WebAssenbly.Tests.Acceptance.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using Xunit;
+
+namespace RESTFulSense.WebAssenbly.Tests.Acceptance.Tests
+{
+    public partial class RestfulSenseWebAssemblyFactoryApiClientTests
+    {
+        [Fact]
+        private void ShouldSendContentWithNoResponseAndDeserializeContent()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity inputTEntity = randomTEntity;
+            TEntity expectedTEntity = inputTEntity;
+            string mediaType = "application/json";
+            bool ignoreDefaultValues = false;
+            string randomHttpMethodName = GetRandomHttpMethodName();
+
+            this.wiremockServer.Given(Request.Create()
+                .WithPath(relativeUrl)
+                .UsingMethod(randomHttpMethodName))
+                    .RespondWith(Response.Create()
+                        .WithStatusCode(200));
+
+            // when
+            Action actualResponseResult = async () =>
+                await this.webAssemblyApiFactoryClient.SendHttpRequestAsync<TEntity>(
+                    method: randomHttpMethodName,
+                    relativeUrl: relativeUrl,
+                    content: inputTEntity,
+                    mediaType: mediaType,
+                    ignoreDefaultValues: ignoreDefaultValues,
+                    serializationFunction: SerializationContentFunction);
+
+            // then
+            actualResponseResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        private async Task ShouldSendContentWithTContentReturnsTResultAsync()
+        {
+            // given
+            TEntity randomTEntity = GetRandomTEntity();
+            TEntity inputTEntity = randomTEntity;
+            TEntity expectedTEntity = inputTEntity;
+            string mediaType = "text/json";
+            bool ignoreDefaultValues = false;
+            string randomHttpMethodName = GetRandomHttpMethodName();
+
+            string expectedBody =
+               JsonConvert.SerializeObject(randomTEntity);
+
+            this.wiremockServer.Given(
+                Request.Create()
+                .WithPath(relativeUrl)
+                .UsingMethod(randomHttpMethodName))
+                    .RespondWith(
+                        Response.Create()
+                            .WithStatusCode(200)
+                            .WithHeader("Content-Type", mediaType)
+                            .WithBody(expectedBody));
+
+            // when
+            TEntity actualTEntity =
+                await this.webAssemblyApiFactoryClient.SendHttpRequestAsync<TEntity, TEntity>(
+                    method: randomHttpMethodName,
+                    relativeUrl: relativeUrl,
+                    content: inputTEntity,
+                    mediaType: mediaType,
+                    ignoreDefaultValues: ignoreDefaultValues,
+                    serializationFunction: SerializationContentFunction,
+                    deserializationFunction: ContentDeserializationFunction);
+
+            // then
+            actualTEntity.Should().BeEquivalentTo(expectedTEntity);
+        }
+    }
+}

--- a/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyFactoryApiClientTests.cs
+++ b/RESTFulSense.WebAssenbly.Tests.Acceptance/Tests/RestfulSenseWebAssemblyFactoryApiClientTests.cs
@@ -68,6 +68,9 @@ namespace RESTFulSense.WebAssenbly.Tests.Acceptance.Tests
         private static TEntity GetRandomTEntity() =>
             CreateTEntityFiller(GetTestDateTimeOffset()).Create();
 
+        private static string GetRandomHttpMethodName() =>
+            new MnemonicString().GetValue();
+
         private static DateTimeOffset GetTestDateTimeOffset() =>
             new DateTimeOffset(DateTime.Now);
 

--- a/RESTFulSense/Clients/IRESTFulApiClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiClient.cs
@@ -16,8 +16,7 @@ namespace RESTFulSense.Clients
     {
         ValueTask<T> GetContentAsync<T>(
             string relativeUrl,
-            Func<string,
-            ValueTask<T>> deserializationFunction = null);
+            Func<string, ValueTask<T>> deserializationFunction = null);
 
         ValueTask<T> GetContentAsync<T>(
             string relativeUrl,
@@ -145,5 +144,29 @@ namespace RESTFulSense.Clients
 
         ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
             Task<HttpResponseMessage> function);
+
+        ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            CancellationToken cancellationToken,
+            Func<string, ValueTask<T>> deserailizationFunction = null);
+
+        ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<T, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<T>> deserializationFunction = null);
+
+        ValueTask<TResult> SendHttpRequestAsync<TContent, TResult>(
+            string method,
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<TContent, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<TResult>> deserializationFunction = null);
     }
 }

--- a/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/IRESTFulApiFactoryClient.cs
@@ -143,5 +143,29 @@ namespace RESTFulSense.Clients
 
         ValueTask<HttpResponseMessage> ExecuteHttpCallAsync(
             Task<HttpResponseMessage> function);
+
+        ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            CancellationToken cancellationToken,
+            Func<string, ValueTask<T>> deserailizationFunction = null);
+
+        ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<T, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<T>> deserializationFunction = null);
+
+        ValueTask<TResult> SendHttpRequestAsync<TContent, TResult>(
+            string method,
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<TContent, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<TResult>> deserializationFunction = null);
     }
 }

--- a/RESTFulSense/Clients/RESTFulApiClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiClient.cs
@@ -453,5 +453,88 @@ namespace RESTFulSense.Clients
 
             return httpResponseMessage;
         }
+
+        public async ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            CancellationToken cancellationToken,
+            Func<string, ValueTask<T>> deserializationFunction = null)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await SendAsync(
+                    request: new HttpRequestMessage(httpMethod, relativeUrl),
+                    cancellationToken: cancellationToken);
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent<T>(
+                responseMessage, deserializationFunction);
+        }
+
+        public async ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<T, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<T>> deserializationFunction = null)
+        {
+            HttpContent contentString =
+                await ConvertToHttpContent(
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
+                    serializationFunction);
+
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await SendAsync(
+                    request: new HttpRequestMessage(httpMethod, relativeUrl)
+                    {
+                        Content = contentString
+                    });
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent<T>(
+                responseMessage,
+                deserializationFunction);
+        }
+
+        public async ValueTask<TResult> SendHttpRequestAsync<TContent, TResult>(
+            string method,
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<TContent, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<TResult>> deserializationFunction = null)
+        {
+            HttpContent contentString =
+                await ConvertToHttpContent(
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
+                    serializationFunction);
+
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await SendAsync(
+                    request: new HttpRequestMessage(httpMethod, relativeUrl)
+                    {
+                        Content = contentString
+                    });
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent(
+                responseMessage,
+                deserializationFunction);
+        }
     }
 }

--- a/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
+++ b/RESTFulSense/Clients/RESTFulApiFactoryClient.cs
@@ -492,5 +492,90 @@ namespace RESTFulSense.Clients
 
             return httpResponseMessage;
         }
+
+        public async ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            CancellationToken cancellationToken,
+            Func<string, ValueTask<T>> deserializationFunction = null)
+        {
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await this.httpClient.SendAsync(
+                    request: new HttpRequestMessage(httpMethod, relativeUrl),
+                    cancellationToken: cancellationToken);
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent<T>(
+                responseMessage, deserializationFunction);
+        }
+
+        public async ValueTask<T> SendHttpRequestAsync<T>(
+            string method,
+            string relativeUrl,
+            T content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<T, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<T>> deserializationFunction = null)
+        {
+            HttpContent contentString =
+                await ConvertToHttpContent(
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
+                    serializationFunction);
+
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await this.httpClient.SendAsync(
+                    request: new HttpRequestMessage
+                    {
+                        Method = httpMethod,
+                        RequestUri = new Uri(relativeUrl),
+                        Content = contentString
+                    });
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent<T>(
+                responseMessage,
+                deserializationFunction);
+        }
+
+        public async ValueTask<TResult> SendHttpRequestAsync<TContent, TResult>(
+            string method,
+            string relativeUrl,
+            TContent content,
+            string mediaType = "text/json",
+            bool ignoreDefaultValues = false,
+            Func<TContent, ValueTask<string>> serializationFunction = null,
+            Func<string, ValueTask<TResult>> deserializationFunction = null)
+        {
+            HttpContent contentString =
+                await ConvertToHttpContent(
+                    content,
+                    mediaType,
+                    ignoreDefaultValues,
+                    serializationFunction);
+
+            var httpMethod = new HttpMethod(method);
+
+            HttpResponseMessage responseMessage =
+                await this.httpClient.SendAsync(
+                    request: new HttpRequestMessage(httpMethod, relativeUrl)
+                    {
+                        Content = contentString
+                    });
+
+            await ValidationService.ValidateHttpResponseAsync(responseMessage);
+
+            return await DeserializeResponseContent(
+                responseMessage,
+                deserializationFunction);
+        }
     }
 }

--- a/RESTFulSense/Models/Attributes/HttpCustomAttribute.cs
+++ b/RESTFulSense/Models/Attributes/HttpCustomAttribute.cs
@@ -1,0 +1,14 @@
+﻿// ----------------------------------------------------------------------------------
+// Copyright (c) The Standard Organization: A coalition of the Good-Hearted Engineers
+// ----------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc.Routing;
+
+namespace RESTFulSense.Models.Attributes
+{
+    public class HttpCustomAttribute : HttpMethodAttribute
+    {
+        public HttpCustomAttribute(string httpVerb)
+            : base(new[] { httpVerb }) { }
+    }
+}


### PR DESCRIPTION
In this update, I'm going to offer support for custom `HttpMethod` with client methods that support communicating with APIs that offer this capability.

Here's some examples:

## Server-Side
Let's say we have a controller that will receive `UPSERT` call instead of the conventional methods such as `POST` or `GET` - here's how to setup your controller:

```csharp
    [ApiController]
    [Route("api/[controller]")]
    public class HomeController : RESTFulController
    {
        [HttpCustom("UPSERT")]
        public IActionResult UpsertStudent(Student student) =>
            Ok(student);
    }
```

Now, let's create an API call using any client like Postman:

<img width="407" alt="image" src="https://github.com/hassanhabib/RESTFulSense/assets/1453985/689b0a47-838d-49bb-983e-cbc7a6318b2a">

## Client-Side
Now, let's switch to the consumer side where we want to execute an `UPSERT` call - this PR will support making the same call we did in Postman as follows:

```csharp
var client = new HttpClient();
var restfulSenseClient = new RESTFulApiClient();

restfulSenseClient.BaseAddress =
    new Uri("https://localhost:7172/");

var student = new Student
{
    Name = "John Doe",
    Age = 25
};

Student studentResponse = await restfulSenseClient.SendHttpRequestAsync<Student>(
    method: "UPSERT",
    relativeUrl: "api/home",
    content: student);

Console.WriteLine($"Student Name: {studentResponse.Name}");
```


